### PR TITLE
[BE] [13-01] Dockerfile 생성 및 클라우드 환경에 배포

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+ADD . /app
+
+RUN yarn workspace server build
+
+EXPOSE 3000
+
+ENTRYPOINT ["yarn", "workspace", "server", "start:prod"]


### PR DESCRIPTION
### 📎 이슈번호

#75 [13-01] Dockerfile 작성

### 📃 변경사항

- node:20-alpine 이미지를 기반으로 BE 프로젝트를 build하여 3000번 포트 열고 실행

### 📌 중점적으로 볼 부분

```ts
FROM node:20-alpine

WORKDIR /app

ADD . /app

RUN yarn workspace server build

EXPOSE 3000

ENTRYPOINT ["yarn", "workspace", "server", "start:prod"]
```

```bash
# 로컬 PC의 프로젝트 루트폴더에서

docker build -t qkrwogk/web16-b1g1-be --platform linux/amd64 .

docker login -u qkrwogk

docker push qkrwogk/web16-b1g1-be


# 클라우드 인스턴스에서

docker pull qkrwogk/web16-b1g1-be

docker container run --name be -d -p 80:3000 qkrwogk/web16-b1g1-be
```

### 🎇 동작 화면

<img width="660" alt="스크린샷 2023-11-13 오후 9 40 27" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/3d3bf815-1d8f-433e-a23b-0a7cbb377096">

<img width="1444" alt="스크린샷 2023-11-13 오후 9 43 59" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/ef908e1d-5108-4f09-ab6f-bd6138dfc9a2">

NCP 환경에 첫 배포를 성공했다!

### 💫 기타사항

해당 Dockerfile로 docker build하여 이미지를 생성하고, docker hub에 push 후 
클라우드 Server 인스턴스에서 이를 pull 하여 실행하면 된다. 

#### 주의사항

<img width="435" alt="docker platform 문제" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/8b4250bb-59e5-4ba6-8776-d37c84f47fe7">

로컬 환경(macOS, arm64)과 클라우드 인스턴스의 하드웨어 플랫폼(ubuntu, amd64)이 달라
docker 이미지를 옵션 없이 생성해서 옮기면 실행이 되지 않는 문제가 있었다. 

따라서 docker build 시 꼭 다음과 같이 `--platform`으로 실행환경의 플랫폼을 명시해줘야 한다.

```bash
docker build -t qkrwogk/web16-b1g1-be --platform linux/amd64 .
```

#### TODO

위 docker build부터 push, pull, 실행까지의 과정을 GitHub Actions로 자동화해야 함.