### PR TITLE
[BE] [06-02] GET /board/:id TDD로 구현 #39

### DIFF
--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -27,8 +27,8 @@ export class BoardController {
 	}
 
 	@Get(':id')
-	findOne(@Param('id') id: string) {
-		return this.boardService.findOne(+id);
+	getBoardById(@Param('id') id: string): Promise<Board> {
+		return this.boardService.getBoardById(+id);
 	}
 
 	@Patch(':id')

--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -27,8 +27,8 @@ export class BoardController {
 	}
 
 	@Get(':id')
-	getBoardById(@Param('id') id: string): Promise<Board> {
-		return this.boardService.getBoardById(+id);
+	findBoardById(@Param('id') id: string): Promise<Board> {
+		return this.boardService.findBoardById(+id);
 	}
 
 	@Patch(':id')

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -29,8 +29,10 @@ export class BoardService {
 		return `This action returns all board`;
 	}
 
-	findOne(id: number) {
-		return `This action returns a #${id} board`;
+	async findOne(id: number) {
+		const found: Board = await this.boardRepository.findOneBy({ id });
+
+		return found;
 	}
 
 	update(id: number, updateBoardDto: UpdateBoardDto) {

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -29,9 +29,11 @@ export class BoardService {
 		return `This action returns all board`;
 	}
 
-	async findOne(id: number) {
+	async getBoardById(id: number): Promise<Board> {
 		const found: Board = await this.boardRepository.findOneBy({ id });
-
+		if (!found) {
+			throw new NotFoundException(`Not found board with id: ${id}`);
+		}
 		return found;
 	}
 

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -29,7 +29,7 @@ export class BoardService {
 		return `This action returns all board`;
 	}
 
-	async getBoardById(id: number): Promise<Board> {
+	async findBoardById(id: number): Promise<Board> {
 		const found: Board = await this.boardRepository.findOneBy({ id });
 		if (!found) {
 			throw new NotFoundException(`Not found board with id: ${id}`);

--- a/packages/server/test/board/board.e2e-spec.ts
+++ b/packages/server/test/board/board.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../src/app.module';
+import { Board } from '../../src/board/entities/board.entity';
 
 describe('BoardController (e2e)', () => {
 	let app: INestApplication;
@@ -17,7 +18,20 @@ describe('BoardController (e2e)', () => {
 
 	describe('/board', () => {
 		// #39 [06-02] 서버는 사용자의 글 데이터를 전송한다.
-		it.todo('GET /board/:id');
+		it('GET /board/:id', async () => {
+			const response = await request(app.getHttpServer())
+				.get('/board/1')
+				.expect(200);
+
+			expect(response).toHaveProperty('body');
+			expect((response as any).body).toHaveProperty('id');
+			expect(response.body.id).toBe(1);
+			expect((response as any).body).toHaveProperty('title');
+			expect((response as any).body).toHaveProperty('content');
+			expect((response as any).body).toHaveProperty('author');
+			expect((response as any).body).toHaveProperty('created_at');
+			expect((response as any).body).toHaveProperty('updated_at');
+		});
 
 		// (추가 필요) 서버는 사용자의 글 목록을 전송한다.
 		it.todo('GET /board');


### PR DESCRIPTION
### 📎 이슈번호

#39 [06-02] 서버는 사용자의 글 데이터를 전송한다. 

### 📃 변경사항

- GET /board/:id 실패하는 테스트 코드 작성
- 테스트 통과하도록 로직 구현
- 함수명 변경, 리턴 타입 명시 등 리팩토링 및 Not Found 에러 처리

### 📌 중점적으로 볼 부분

- [앞선 PR](https://github.com/boostcampwm2023/web16-B1G1/pull/82)과 동일하게 TDD로 GET /board/:id 구현
- RED, GREEN, REFACTOR 3 단계로 구현 수행 및 커밋함

### 🎇 동작 화면

#### RED

<img width="1078" alt="스크린샷 2023-11-15 오후 5 48 09" src="https://user-images.githubusercontent.com/138586629/283057416-e1ef503e-5b08-4f8c-92c0-2fc79d0c2225.png">

#### GREEN

<img width="1085" alt="스크린샷 2023-11-15 오후 6 00 29" src="https://user-images.githubusercontent.com/138586629/283061044-b2c70cc0-dc42-4064-b206-e8997c886f1a.png">

#### REFACTOR

<img width="1021" alt="스크린샷 2023-11-15 오후 6 15 19" src="https://user-images.githubusercontent.com/138586629/283065019-bad0bb23-2773-476a-a418-f9d4375da6ba.png">

<img width="1028" alt="스크린샷 2023-11-15 오후 6 13 34" src="https://user-images.githubusercontent.com/138586629/283064544-bd336341-594c-4a89-845f-ccdfc8b625c5.png">

### 💫 기타사항

#### 개발 기록

[[재하] 1115(수) 개발기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%9E%AC%ED%95%98%5D-1115(%EC%88%98)-%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D)
