### PR TITLE
[BE] [06-13] 서버는 사용자 요청에 따라 글 목록을 전송한다.

### DIFF
--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -22,8 +22,8 @@ export class BoardController {
 	}
 
 	@Get()
-	findAll() {
-		return this.boardService.findAll();
+	findAllBoards(): Promise<Board[]> {
+		return this.boardService.findAllBoards();
 	}
 
 	@Get(':id')

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -25,7 +25,7 @@ export class BoardService {
 		return created;
 	}
 
-	async findAll() {
+	async findAllBoards(): Promise<Board[]> {
 		const boards = await this.boardRepository.find();
 		return boards;
 	}

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -25,8 +25,9 @@ export class BoardService {
 		return created;
 	}
 
-	findAll() {
-		return `This action returns all board`;
+	async findAll() {
+		const boards = await this.boardRepository.find();
+		return boards;
 	}
 
 	async findBoardById(id: number): Promise<Board> {

--- a/packages/server/test/board/board.e2e-spec.ts
+++ b/packages/server/test/board/board.e2e-spec.ts
@@ -34,7 +34,20 @@ describe('BoardController (e2e)', () => {
 		});
 
 		// (추가 필요) 서버는 사용자의 글 목록을 전송한다.
-		it.todo('GET /board');
+		it('GET /board', async () => {
+			const response = await request(app.getHttpServer())
+				.get('/board')
+				.expect(200);
+
+			expect(response).toHaveProperty('body');
+			expect(response.body).toBeInstanceOf(Array);
+
+			const boards = response.body as Board[];
+			if (boards.length > 0) {
+				expect(boards[0]).toHaveProperty('id');
+				expect(boards[0]).toHaveProperty('title');
+			}
+		});
 
 		// #45 [06-08] 서버는 좋아요 / 좋아요 취소 요청을 받아 데이터베이스의 데이터를 수정한다.
 		it.todo('PATCH /board/:id/like');


### PR DESCRIPTION
### 📎 이슈번호

#84 [06-13] 서버는 사용자 요청에 따라 글 목록을 전송한다.

### 📃 변경사항

- GET /board 요청에 대해
  - 실패하는 테스트 코드 작성
  - 성공하도록 구현
  - 리팩토링

### 📌 중점적으로 볼 부분

- 실패하는 테스트 코드 작성
- 성공하도록 구현
- 리팩토링

### 🎇 동작 화면

#### RED

<img width="944" alt="스크린샷 2023-11-16 오후 1 33 06" src="https://user-images.githubusercontent.com/138586629/283322001-d07a7c58-d8d6-4ae0-bab1-d6b7c50c1f68.png">

#### GREEN

<img width="953" alt="스크린샷 2023-11-16 오후 1 37 26" src="https://user-images.githubusercontent.com/138586629/283322612-b6b05148-573e-4e15-8d58-014166a8b5e8.png">

#### REFACTOR

<img width="954" alt="스크린샷 2023-11-16 오후 1 41 32" src="https://user-images.githubusercontent.com/138586629/283323239-8747b563-682b-42a7-a091-0caf6cf4bd27.png">

<img width="1012" alt="스크린샷 2023-11-16 오후 1 41 57" src="https://user-images.githubusercontent.com/138586629/283323302-00d95f9d-476b-4530-b01d-0635beeb6995.png">

### 💫 기타사항
