### PR TITLE
[FE] [06-04] 별 클릭시 해당 방향으로 카메라 시점 이동하도록 설정

### DIFF
--- a/packages/client/src/components/feature/Controls/Controls.tsx
+++ b/packages/client/src/components/feature/Controls/Controls.tsx
@@ -2,12 +2,25 @@ import { useRef } from 'react';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
 import { useCameraStore } from 'store/useCameraStore';
-import { useFrame } from '@react-three/fiber';
+import { Camera, useFrame } from '@react-three/fiber';
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
+
+function setCameraPosition(
+	camera: Camera,
+	currentView: THREE.Vector3,
+	distance: number,
+) {
+	const direction = currentView
+		.clone()
+		.sub(camera.position)
+		.setLength(camera.position.distanceTo(currentView) - distance);
+	camera.position.add(direction);
+}
 
 export default function Controls() {
 	const controlsRef = useRef<OrbitControlsImpl>(null!);
-	const { currentView, setCurrentView, targetView } = useCameraStore();
+	const { distance, currentView, setCurrentView, targetView } =
+		useCameraStore();
 
 	useFrame((state, delta) => {
 		const targetPosition = new THREE.Vector3(0, 0, 0);
@@ -21,7 +34,7 @@ export default function Controls() {
 			if (direction.length() > LENGTH_LIMIT) direction.setLength(LENGTH_LIMIT);
 
 			setCurrentView(currentView.add(direction));
-			state.camera.position.add(direction);
+			setCameraPosition(state.camera, currentView, distance);
 
 			controlsRef.current.target = currentView;
 		}

--- a/packages/client/src/components/feature/Galaxy/index.tsx
+++ b/packages/client/src/components/feature/Galaxy/index.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import Star from '../Star';
 import { getRandomInt, getGaussianRandomFloat } from '@utils/random';
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import {
 	ARMS,
@@ -31,43 +31,46 @@ const getSpiralPositions = (offset: number) => {
 
 export default function Galaxy() {
 	const galaxyRef = useRef<THREE.Group>(null!);
-	const stars = [];
 
-	useFrame((_, delta) => (galaxyRef.current.rotation.y += delta / 100));
+	useFrame((_, delta) => (galaxyRef.current.rotation.y += delta / 200));
 
-	for (let arm = 0; arm < ARMS; arm++) {
+	const stars = useMemo(() => {
+		const starList = [];
+		for (let arm = 0; arm < ARMS; arm++) {
+			for (let star = 0; star < STARS_NUM / (ARMS + 1); star++) {
+				const size = getRandomInt(STAR_MIN_SIZE, STAR_MAX_SIZE);
+				const position = getSpiralPositions((arm * 2 * Math.PI) / ARMS);
+
+				starList.push(
+					<Star
+						key={`${arm}${star}`}
+						position={position}
+						size={size}
+						color={'#FFF'}
+					/>,
+				);
+			}
+		}
+
 		for (let star = 0; star < STARS_NUM / (ARMS + 1); star++) {
 			const size = getRandomInt(STAR_MIN_SIZE, STAR_MAX_SIZE);
-			const position = getSpiralPositions((arm * 2 * Math.PI) / ARMS);
+			const position = new THREE.Vector3(
+				getGaussianRandomFloat(0, (ARMS_X_MEAN + ARMS_X_DIST) / 4),
+				getGaussianRandomFloat(0, GALAXY_THICKNESS * 2),
+				getGaussianRandomFloat(0, (ARMS_X_MEAN + ARMS_X_DIST) / 4),
+			);
 
-			stars.push(
+			starList.push(
 				<Star
-					key={`${arm}${star}`}
+					key={`star_${star}`}
 					position={position}
 					size={size}
 					color={'#FFF'}
 				/>,
 			);
 		}
-	}
-
-	for (let star = 0; star < STARS_NUM / (ARMS + 1); star++) {
-		const size = getRandomInt(STAR_MIN_SIZE, STAR_MAX_SIZE);
-		const position = new THREE.Vector3(
-			getGaussianRandomFloat(0, (ARMS_X_MEAN + ARMS_X_DIST) / 4),
-			getGaussianRandomFloat(0, GALAXY_THICKNESS * 2),
-			getGaussianRandomFloat(0, (ARMS_X_MEAN + ARMS_X_DIST) / 4),
-		);
-
-		stars.push(
-			<Star
-				key={`star_${star}`}
-				position={position}
-				size={size}
-				color={'#FFF'}
-			/>,
-		);
-	}
+		return starList;
+	}, []);
 
 	return <group ref={galaxyRef}>{stars}</group>;
 }

--- a/packages/client/src/components/feature/Screen/index.tsx
+++ b/packages/client/src/components/feature/Screen/index.tsx
@@ -5,6 +5,7 @@ import { EffectComposer, Bloom } from '@react-three/postprocessing';
 import { useControls } from 'leva';
 import { CAMERA_POSITION, CAMERA_ROTATION, CAMERA_FAR } from 'constants/camera';
 import Controls from '../Controls/Controls.tsx';
+import { useCameraStore } from 'store/useCameraStore.ts';
 
 export default function Screen() {
 	const camera = {
@@ -12,6 +13,8 @@ export default function Screen() {
 		rotation: CAMERA_ROTATION,
 		far: CAMERA_FAR,
 	};
+
+	const { distance, setDistance } = useCameraStore();
 
 	const { intensity, mipmapBlur, luminanceThreshold, luminanceSmoothing } =
 		useControls('Bloom', {
@@ -23,7 +26,10 @@ export default function Screen() {
 
 	return (
 		<div style={{ height: '100vh', width: '100vw' }}>
-			<Canvas camera={camera}>
+			<Canvas
+				camera={camera}
+				onWheel={(e) => setDistance(distance + e.deltaY / 20)}
+			>
 				<EffectComposer>
 					<Bloom
 						intensity={intensity}

--- a/packages/client/src/store/useCameraStore.ts
+++ b/packages/client/src/store/useCameraStore.ts
@@ -6,6 +6,8 @@ interface cameraState {
 	setCurrentView: (position: THREE.Vector3) => void;
 	targetView: THREE.Mesh | null;
 	setTargetView: (star: THREE.Mesh | null) => void;
+	distance: number;
+	setDistance: (distance: number) => void;
 }
 
 export const useCameraStore = create<cameraState>()((set) => ({
@@ -13,4 +15,7 @@ export const useCameraStore = create<cameraState>()((set) => ({
 	setCurrentView: (position: THREE.Vector3) => set({ currentView: position }),
 	targetView: null,
 	setTargetView: (star: THREE.Mesh | null) => set({ targetView: star }),
+	distance: 100,
+	setDistance: (distance: number) =>
+		set({ distance: distance > 100 ? distance : 100 }),
 }));


### PR DESCRIPTION
### 📎 이슈번호
#41 

### 📃 변경사항
- Galaxy 컴포넌트가 Star 컴포넌트를을 기억하지 않았던 부분을 기억하도록 개선
- 기존에 직선적인 움직임을 보였던 카메라 움직임을 포물선을 그리며 자연스럽게 움직이도록 개선
- 은하가 회전함에 따라 카메라와 바라보는 별 사이의 거리가 변하던 문제를 distance를 저장해 유지하도록 수정

### 📌 중점적으로 볼 부분
- 카메라 움직임이 충분히 자연스러워 졌는가
- 카메라와 별 사이의 거리가 일정하게 유지되는가

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/78800560/7927e626-cac3-4ea8-8140-e0d871ec21ba


### 💫 기타사항
- 카메라와 바라보는 별 사이의 거리가 너무 가까우면 카메라 움직임이 너무 빠른 경우가 있다.
- 카메라와 바라보는 별 사이의 거리가 너무 가까우면 별이 화면의 가운데서 약간씩 흔들린다.
- 성능적인 부분을 고려해 추가적인 최적화가 필요할 수 있다.
