### PR TITLE
[FE] [04-09] 페이지 간 이동시 보여줄 화면 제작

### DIFF
--- a/packages/client/src/components/feature/SpaceWarp/indes.tsx
+++ b/packages/client/src/components/feature/SpaceWarp/indes.tsx
@@ -1,0 +1,65 @@
+import { getRandomFloat, getRandomInt } from '@utils/random';
+import { BACKGROUND_STAR_COLORS } from 'constants/backgroundStars';
+import { useMemo, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+const SPACE_WARP_LINES_NUM = 1500;
+const SPACE_WARP_LINE_LENGTH = 10000;
+const SPACE_WARP_Y_MAX = 100000;
+const SPACE_WARP_Y_MIN = -100000;
+const SPACE_WARP_XZ_MAX = 10000;
+const SPACE_WARP_XZ_MIN = -10000;
+
+const geSpaceWarpLinesInfo = () => {
+	const positions = Array.from({ length: SPACE_WARP_LINES_NUM }, () => {
+		const x = getRandomFloat(SPACE_WARP_XZ_MIN, SPACE_WARP_XZ_MAX);
+		const y = getRandomFloat(SPACE_WARP_Y_MIN, SPACE_WARP_Y_MAX);
+		const z = getRandomFloat(SPACE_WARP_XZ_MIN, SPACE_WARP_XZ_MAX);
+
+		return [x, y, z, x, y - SPACE_WARP_LINE_LENGTH, z];
+	}).flat();
+
+	const colors = Array.from({ length: SPACE_WARP_LINES_NUM }, () => {
+		const color = new THREE.Color(
+			BACKGROUND_STAR_COLORS[getRandomInt(0, BACKGROUND_STAR_COLORS.length)],
+		);
+
+		return [color.r, color.g, color.b];
+	}).flat();
+
+	return [new Float32Array(positions), new Float32Array(colors)];
+};
+
+export default function SpaceWarp() {
+	const linesRef = useRef<THREE.LineSegments>(null!);
+
+	const [positions, colors] = useMemo(() => geSpaceWarpLinesInfo(), []);
+
+	useThree().camera.position.set(0, 100000, 0);
+
+	useFrame((state) => {
+		state.camera.position.y -= 250;
+		state.camera.lookAt(0, -500000, 0);
+	});
+
+	return (
+		<lineSegments ref={linesRef}>
+			<bufferGeometry attach="geometry">
+				<bufferAttribute
+					attach="attributes-position"
+					count={SPACE_WARP_LINES_NUM}
+					array={positions}
+					itemSize={3}
+				/>
+				<bufferAttribute
+					attach="attributes-color"
+					count={SPACE_WARP_LINES_NUM}
+					array={colors}
+					itemSize={3}
+				/>
+			</bufferGeometry>
+			<lineBasicMaterial attach="material" vertexColors={true} />
+		</lineSegments>
+	);
+}

--- a/packages/client/src/components/feature/SpaceWarp/index.tsx
+++ b/packages/client/src/components/feature/SpaceWarp/index.tsx
@@ -1,6 +1,6 @@
 import { getRandomFloat, getRandomInt } from '@utils/random';
 import { BACKGROUND_STAR_COLORS } from 'constants/backgroundStars';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import {

--- a/packages/client/src/components/feature/SpaceWarp/index.tsx
+++ b/packages/client/src/components/feature/SpaceWarp/index.tsx
@@ -1,15 +1,16 @@
 import { getRandomFloat, getRandomInt } from '@utils/random';
 import { BACKGROUND_STAR_COLORS } from 'constants/backgroundStars';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-
-const SPACE_WARP_LINES_NUM = 1500;
-const SPACE_WARP_LINE_LENGTH = 10000;
-const SPACE_WARP_Y_MAX = 100000;
-const SPACE_WARP_Y_MIN = -100000;
-const SPACE_WARP_XZ_MAX = 10000;
-const SPACE_WARP_XZ_MIN = -10000;
+import {
+	SPACE_WARP_LINES_NUM,
+	SPACE_WARP_LINE_LENGTH,
+	SPACE_WARP_XZ_MAX,
+	SPACE_WARP_XZ_MIN,
+	SPACE_WARP_Y_MAX,
+	SPACE_WARP_Y_MIN,
+} from 'constants/spaceWarp';
 
 const geSpaceWarpLinesInfo = () => {
 	const positions = Array.from({ length: SPACE_WARP_LINES_NUM }, () => {

--- a/packages/client/src/components/feature/Star/index.tsx
+++ b/packages/client/src/components/feature/Star/index.tsx
@@ -14,7 +14,7 @@ export default function Star({ position, size, color }: PropsType) {
 	const meshRef = useRef<THREE.Mesh>(null!);
 	const { targetView, setTargetView } = useCameraStore();
 
-	useFrame((state, delta) => {
+	useFrame((state) => {
 		const cameraDistance = new THREE.Vector3(0, 0, 0).distanceTo(
 			state.camera.position,
 		);

--- a/packages/client/src/constants/spaceWarp.ts
+++ b/packages/client/src/constants/spaceWarp.ts
@@ -1,0 +1,6 @@
+export const SPACE_WARP_LINES_NUM = 1500;
+export const SPACE_WARP_LINE_LENGTH = 10000;
+export const SPACE_WARP_Y_MAX = 100000;
+export const SPACE_WARP_Y_MIN = -100000;
+export const SPACE_WARP_XZ_MAX = 10000;
+export const SPACE_WARP_XZ_MIN = -10000;

--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Screen from '../../components/feature/Screen';
 
 export default function Home() {


### PR DESCRIPTION
### 📎 이슈번호
#98 

### 📃 변경사항
- 공간을 통과하는 듯한 느낌을 주는 애니메이션 생성

### 📌 중점적으로 볼 부분
- useFrame 부분

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/76a86386-a89d-49a2-9880-90dede04b58f

### 💫 기타사항
- 색상같은 것은 임시로 해두었습니다.
- 디자인 확정이 아니라 대략적인 느낌만 봐주시면 될 것 같습니다.
- 몇 초 지난 후 화면의 중앙부터 서서히 흰색으로 변하는 애니메이션을 구현할까 했는데... 
  -  화면이 한 번에 흰색으로 변하는 것까진 됐는데, 중앙부터 서서히 변하는 것은 아직 구현하지 못했습니다.
  - 하단에 엄청 쎈 광원을 두어 밑으로 내려가면서 점점 하얘지는.. 그런 연출도 가능할까요?? 
  - 아무튼 이 부분도 확정이 아니라 그냥 시도해본거라 커밋은 하지 않았습니다. 
   - 수정하면 좋을 부분이나, 처음과 끝에 넣으면 좋을 애니메이션이 있다면 알려주세요.
  
- 기존 backgroundStars 컴포넌트를 변형하여 만들었습니다.
  - positions 부분에 차이가 있습니다.
    - 점이 아닌 선이므로 x, y, z 좌표를 두 번씩 넣습니다.  
  - lineSegments와 LineBasicMaterial을 사용합니다.

- 우주공간의 x, z 범위는 줄이고 y 범위를 늘렸습니다. 

- y범위의 끝에서 카메라가 서서히 내려가는 식으로 동작합니다. 
- 카메라가 우주의 끝을 넘어서면 더이상 애니메이션이 보이지 않습니다.
- 실제로는 몇 초간만 보여주고 끝낼 화면이라 그 부분은 신경쓰지 않았습니다.
