### PR TITLE
[BE] SignIn시 RefreshToken 발급 및 Redis에 저장

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -106,14 +106,4 @@ export class AuthController {
 	isAvailableNickname(@Query('nickname') nickname: string) {
 		return this.authService.isAvailableNickname(nickname);
 	}
-
-	@Get('redis')
-	getValueFromRedis(@Query('key') key: string) {
-		return this.authService.getValueFromRedis(key);
-	}
-
-	@Post('redis')
-	setValueToRedis(@Body() { key, value }: { key: string; value: string }) {
-		return this.authService.setValueToRedis(key, value);
-	}
 }

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -23,6 +23,7 @@ import {
 	ApiTags,
 	ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { JwtEnum } from './enums/jwt.enum';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -54,11 +55,11 @@ export class AuthController {
 		@Res({ passthrough: true }) res: Response,
 	) {
 		const tokens = await this.authService.signIn(signInUserDto);
-		res.cookie('accessToken', tokens.accessToken, {
+		res.cookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, tokens.accessToken, {
 			path: '/',
 			httpOnly: true,
 		});
-		res.cookie('refreshToken', tokens.refreshToken, {
+		res.cookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, tokens.refreshToken, {
 			path: '/',
 			httpOnly: true,
 		});

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -53,14 +53,17 @@ export class AuthController {
 		@Body() signInUserDto: SignInUserDto,
 		@Res({ passthrough: true }) res: Response,
 	) {
-		const result = await this.authService.signIn(signInUserDto);
-		// res.setHeader('Authorization', `Bearer ${result.accessToken}`);
-		res.cookie('accessToken', result.accessToken, {
+		const tokens = await this.authService.signIn(signInUserDto);
+		res.cookie('accessToken', tokens.accessToken, {
+			path: '/',
+			httpOnly: true,
+		});
+		res.cookie('refreshToken', tokens.refreshToken, {
 			path: '/',
 			httpOnly: true,
 		});
 
-		return result;
+		return tokens;
 	}
 
 	@Get('signout')

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -86,15 +86,4 @@ export class AuthService {
 			return true;
 		}
 	}
-
-	async getValueFromRedis(key: string) {
-		const value = await this.redisRepository.get(key);
-		return {
-			value,
-		};
-	}
-
-	async setValueToRedis(key: string, value: string) {
-		return this.redisRepository.set(key, value);
-	}
 }

--- a/packages/server/src/auth/decorators/user-constraints.decorator.ts
+++ b/packages/server/src/auth/decorators/user-constraints.decorator.ts
@@ -4,20 +4,20 @@ import {
 	ValidatorConstraint,
 	ValidatorConstraintInterface,
 } from 'class-validator';
-import { SignUpEnum } from '../enums/signup.enum';
+import { UserEnum } from '../enums/user.enum';
 
 @ValidatorConstraint({ name: 'isUsername', async: false })
 export class IsUsernameConstraint implements ValidatorConstraintInterface {
 	validate(username: string): boolean {
 		const isEngAndNum = /^[a-zA-Z0-9]+$/.test(username);
 		const checkLength =
-			username.length >= SignUpEnum.MIN_USERNAME_LENGTH &&
-			username.length <= SignUpEnum.MAX_USERNAME_LENGTH;
+			username.length >= UserEnum.MIN_USERNAME_LENGTH &&
+			username.length <= UserEnum.MAX_USERNAME_LENGTH;
 		return isEngAndNum && checkLength;
 	}
 
 	defaultMessage(): string {
-		return SignUpEnum.VIOLATE_USERNAME_MESSAGE;
+		return UserEnum.VIOLATE_USERNAME_MESSAGE;
 	}
 }
 
@@ -37,13 +37,13 @@ export function IsUsername(validationOptions?: ValidationOptions) {
 export class IsPasswordConstraint implements ValidatorConstraintInterface {
 	validate(password: string): boolean {
 		return (
-			password.length >= SignUpEnum.MIN_PASSWORD_LENGTH &&
-			password.length <= SignUpEnum.MAX_PASSWORD_LENGTH
+			password.length >= UserEnum.MIN_PASSWORD_LENGTH &&
+			password.length <= UserEnum.MAX_PASSWORD_LENGTH
 		);
 	}
 
 	defaultMessage(): string {
-		return SignUpEnum.VIOLATE_PASSWORD_MESSAGE;
+		return UserEnum.VIOLATE_PASSWORD_MESSAGE;
 	}
 }
 
@@ -64,13 +64,13 @@ export class IsNicknameConstraint implements ValidatorConstraintInterface {
 	validate(nickname: string): boolean {
 		const isEngAndNumAndKor = /^[a-zA-Z0-9가-힣]+$/.test(nickname);
 		const checkLength =
-			nickname.length >= SignUpEnum.MIN_NICKNAME_LENGTH &&
-			nickname.length <= SignUpEnum.MAX_NICKNAME_LENGTH;
+			nickname.length >= UserEnum.MIN_NICKNAME_LENGTH &&
+			nickname.length <= UserEnum.MAX_NICKNAME_LENGTH;
 		return isEngAndNumAndKor && checkLength;
 	}
 
 	defaultMessage(): string {
-		return SignUpEnum.VIOLATE_NICKNAME_MESSAGE;
+		return UserEnum.VIOLATE_NICKNAME_MESSAGE;
 	}
 }
 

--- a/packages/server/src/auth/dto/signin-user.dto.ts
+++ b/packages/server/src/auth/dto/signin-user.dto.ts
@@ -1,4 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { UserEnum } from '../enums/user.enum';
+import { IsNotEmpty, IsString } from 'class-validator';
+import {
+	IsPassword,
+	IsUsername,
+} from '../decorators/user-constraints.decorator';
 
 export class SignInUserDto {
 	@ApiProperty({
@@ -6,6 +12,9 @@ export class SignInUserDto {
 		example: 'test user',
 		required: true,
 	})
+	@IsNotEmpty({ message: UserEnum.USERNAME_NOTEMPTY_MESSAGE as string })
+	@IsString({ message: UserEnum.USERNAME_ISSTRING_MESSAGE as string })
+	@IsUsername()
 	username: string;
 
 	@ApiProperty({
@@ -13,5 +22,8 @@ export class SignInUserDto {
 		example: 'test password',
 		required: true,
 	})
+	@IsNotEmpty({ message: UserEnum.PASSWORD_NOTEMPTY_MESSAGE as string })
+	@IsString({ message: UserEnum.PASSWORD_ISSTRING_MESSAGE as string })
+	@IsPassword()
 	password: string;
 }

--- a/packages/server/src/auth/dto/signup-user.dto.ts
+++ b/packages/server/src/auth/dto/signup-user.dto.ts
@@ -4,8 +4,8 @@ import {
 	IsNickname,
 	IsPassword,
 	IsUsername,
-} from '../decorators/signup-constraints.decorator';
-import { SignUpEnum } from '../enums/signup.enum';
+} from '../decorators/user-constraints.decorator';
+import { UserEnum } from '../enums/user.enum';
 
 export class SignUpUserDto {
 	@ApiProperty({
@@ -13,8 +13,8 @@ export class SignUpUserDto {
 		example: 'test user',
 		required: true,
 	})
-	@IsNotEmpty({ message: SignUpEnum.USERNAME_NOTEMPTY_MESSAGE as string })
-	@IsString({ message: SignUpEnum.USERNAME_ISSTRING_MESSAGE as string })
+	@IsNotEmpty({ message: UserEnum.USERNAME_NOTEMPTY_MESSAGE as string })
+	@IsString({ message: UserEnum.USERNAME_ISSTRING_MESSAGE as string })
 	@IsUsername()
 	username: string;
 
@@ -23,8 +23,8 @@ export class SignUpUserDto {
 		example: 'test password',
 		required: true,
 	})
-	@IsNotEmpty({ message: SignUpEnum.PASSWORD_NOTEMPTY_MESSAGE as string })
-	@IsString({ message: SignUpEnum.PASSWORD_ISSTRING_MESSAGE as string })
+	@IsNotEmpty({ message: UserEnum.PASSWORD_NOTEMPTY_MESSAGE as string })
+	@IsString({ message: UserEnum.PASSWORD_ISSTRING_MESSAGE as string })
 	@IsPassword()
 	password: string;
 
@@ -33,8 +33,8 @@ export class SignUpUserDto {
 		example: 'test nickname',
 		required: true,
 	})
-	@IsNotEmpty({ message: SignUpEnum.NICKNAME_NOTEMPTY_MESSAGE as string })
-	@IsString({ message: SignUpEnum.NICKNAME_ISSTRING_MESSAGE as string })
+	@IsNotEmpty({ message: UserEnum.NICKNAME_NOTEMPTY_MESSAGE as string })
+	@IsString({ message: UserEnum.NICKNAME_ISSTRING_MESSAGE as string })
 	@IsNickname()
 	nickname: string;
 }

--- a/packages/server/src/auth/enums/jwt.enum.ts
+++ b/packages/server/src/auth/enums/jwt.enum.ts
@@ -1,0 +1,10 @@
+export enum JwtEnum {
+	ACCESS_TOKEN_COOKIE_NAME = 'accessToken',
+	REFRESH_TOKEN_COOKIE_NAME = 'refreshToken',
+
+	ACCESS_TOKEN_TYPE = 'access',
+	REFRESH_TOKEN_TYPE = 'refresh',
+
+	ACCESS_TOKEN_EXPIRES_IN = '1h',
+	REFRESH_TOKEN_EXPIRES_IN = '1d',
+}

--- a/packages/server/src/auth/enums/user.enum.ts
+++ b/packages/server/src/auth/enums/user.enum.ts
@@ -1,4 +1,4 @@
-export enum SignUpEnum {
+export enum UserEnum {
 	MIN_USERNAME_LENGTH = 4,
 	MAX_USERNAME_LENGTH = 50,
 	MIN_PASSWORD_LENGTH = 8,
@@ -16,5 +16,5 @@ export enum SignUpEnum {
 
 	VIOLATE_USERNAME_MESSAGE = `아이디는 영문자와 숫자로 이루어진 ${MIN_USERNAME_LENGTH}~${MAX_USERNAME_LENGTH}자여야 합니다.`,
 	VIOLATE_PASSWORD_MESSAGE = `비밀번호는 ${MIN_PASSWORD_LENGTH}~${MAX_PASSWORD_LENGTH}자여야 합니다.`,
-	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}자여야 합니다.`,
+	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}w자여야 합니다.`,
 }

--- a/packages/server/src/auth/enums/user.enum.ts
+++ b/packages/server/src/auth/enums/user.enum.ts
@@ -16,5 +16,7 @@ export enum UserEnum {
 
 	VIOLATE_USERNAME_MESSAGE = `아이디는 영문자와 숫자로 이루어진 ${MIN_USERNAME_LENGTH}~${MAX_USERNAME_LENGTH}자여야 합니다.`,
 	VIOLATE_PASSWORD_MESSAGE = `비밀번호는 ${MIN_PASSWORD_LENGTH}~${MAX_PASSWORD_LENGTH}자여야 합니다.`,
-	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}w자여야 합니다.`,
+	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}자여야 합니다.`,
+
+	FAIL_SIGNIN_MESSAGE = '아이디에 해당하는 회원이 존재하지 않거나 비밀번호가 일치하지 않습니다.',
 }

--- a/packages/server/src/config/jwt.config.ts
+++ b/packages/server/src/config/jwt.config.ts
@@ -5,7 +5,7 @@ configDotenv();
 const jwtConfig: JwtModuleOptions = {
 	secret: process.env.JWT_SECRET,
 	signOptions: {
-		expiresIn: 3600,
+		expiresIn: 60 * 60,
 	},
 };
 

--- a/packages/server/src/config/jwt.config.ts
+++ b/packages/server/src/config/jwt.config.ts
@@ -1,11 +1,12 @@
 import { JwtModuleOptions } from '@nestjs/jwt';
 import { configDotenv } from 'dotenv';
+import { JwtEnum } from '../auth/enums/jwt.enum';
 configDotenv();
 
 const jwtConfig: JwtModuleOptions = {
 	secret: process.env.JWT_SECRET,
 	signOptions: {
-		expiresIn: 60 * 60,
+		expiresIn: JwtEnum.ACCESS_TOKEN_EXPIRES_IN,
 	},
 };
 


### PR DESCRIPTION
### 📎 이슈번호

#27 [04-04] 데이터베이스에서 로그인 데이터로 조회를 하여 비교한다.

### 📃 변경사항

- 파일 이름 변경
  - signup-contraints.decorator.ts -> user-constraints.decorator.ts
  - signup.enum.ts -> user.enum.ts
- SignInUserDto의 username, password에 대하여 ClassValidator 추가
- Auth Controller, Service에서 Redis 관련 코드 제거
  - api 삭제
  - Service에서 Redis get, set 메서드 삭제
- RefreshToken 발급 로직 추가
  - Service에서 RefreshToken 발급 및 토큰 Redis에 저장
  - Controller에서 RefreshToken도 쿠키에 저장 응답 전송
 - JwtEnum 추가 및 하드코딩 부분들 Enum값으로 수정

### 📌 중점적으로 볼 부분

재하님 저번 피드백 대로 일단 Redis와 직접적으로 통신하는 api를 삭제하고 Service 메서드도 삭제했습니다! 
Service의 특정 로직 안에서 필요시 redisRepository의 로직을 사용하는 느낌으로 하면 될 것 같습니다.

### 🎇 동작 화면
로그인 요청 보낼 시 쿠키에 토큰이 담긴 모습
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/dd164eb7-2dbb-4d21-8f7d-b987a20de25b)


이 두 토큰의 값을 디코딩 해보았다.

1. accessToken
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/36f765f3-76a7-4053-8d9b-d98428c85836)

2.  refreshToken
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/b8ad6a7e-8b2c-427e-b55c-b5eb89fe8c33)

정보가 잘 담겨있는 모습을 확인했다.
유효 기간도 accessToken은 1시간, refreshToken은 하루가 잘 적용되어 있었다.

redis에도 저장이 잘 된 모습을 보였다.
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/0240e92b-a767-4195-9890-dfecccfc5cae)
첫 명렁어를 봤을 때 key가 없었고, signin후 다음 명령어를 실행하니 key가 생겼다.
value에도 refreshToken이 잘 담겨있었다!


### 💫 기타사항
