### PR TITLE
[FE] Search 컴포넌트 생성

### DIFF
--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -53,7 +53,7 @@ const Layout = styled.div`
 	border-radius: 8px;
 	opacity: 90%;
 	padding: 8px;
-	background-color: #05021f;
+	background-color: ${({ theme: { colors } }) => colors.background.bdp01};
 	border: 1px solid ${({ theme: { colors } }) => colors.stroke.default};
 
 	:hover {

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -1,0 +1,76 @@
+import styled from '@emotion/styled';
+import searchIcon from '../../../../public/icons/icon-search-24-white.svg';
+import { Body03ME } from '../styles';
+import Button from '../button/button';
+
+interface PropsTypes {
+	onClick: () => void;
+	placeholder?: string;
+	inputState: string;
+	setInputState: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function Search({
+	onClick,
+	inputState,
+	setInputState,
+	placeholder = '',
+}: PropsTypes) {
+	const onChangeSearchInput = ({
+		target,
+	}: React.ChangeEvent<HTMLInputElement>) => {
+		setInputState(target.value);
+	};
+
+	return (
+		<Layout>
+			<img src={searchIcon} alt="돋보기 아이콘" />
+
+			<SearchInput
+				placeholder={placeholder}
+				onChange={onChangeSearchInput}
+				value={inputState}
+			/>
+
+			{inputState ? (
+				<Button onClick={onClick} size="m" buttonType="CTA-icon">
+					버튼
+				</Button>
+			) : (
+				<Button onClick={onClick} size="m" buttonType="CTA-icon" disabled>
+					버튼
+				</Button>
+			)}
+		</Layout>
+	);
+}
+
+const Layout = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	border-radius: 8px;
+	opacity: 90%;
+	padding: 8px;
+	background-color: #05021f;
+	border: 1px solid ${({ theme: { colors } }) => colors.stroke.default};
+
+	:hover {
+		border: 1px solid ${({ theme: { colors } }) => colors.stroke.focus};
+	}
+`;
+
+const SearchInput = styled.input`
+	border: none;
+	background-color: transparent;
+	outline: none;
+	margin: 0 8px;
+	flex: 1;
+	color: ${({ theme: { colors } }) => colors.text.primary};
+	${Body03ME}
+
+	::placeholder {
+		color: ${({ theme: { colors } }) => colors.text.disabled};
+	}
+`;


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- onClick, placeholder, inputState, setInputState를 props로 받는 Search 컴포넌트 생성
  - 원래는 inputState와 setInputState가 아닌 onChange만 받아왔는데, input 내용 유무에 따라 버튼 상태를 변경하기 위해 useState를 받아오는 식으로 변경했습니다. 더 좋은 방법이 있다면 알려주세요.
  - width는 100%로 주었고, width가 늘어남에 따라 중간의 input의 width가 함께 늘어납니다.
- input이 비어있으면 버튼이 비활성화됩니다.

### 📌 중점적으로 볼 부분
props 받아오는 부분에서 수정할 점이 있다면 알려주세요 

### 🎇 동작 화면
- 뒷배경을 #000으로 주어 테스트했습니다.

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/7e36521e-5191-4f12-8b86-ba520e68a364

### 💫 기타사항
- Layout background 부분 색을 primary.disabled로 줬더니 뭔가 이상해서 일단 #05021F로 해두었습니다. 뭐가 문제일까요.. ㅜ 
  -> 수정했습니다 ! figma에 색 연결이 안되어있었네요 

- @bananaba
  - 버튼이 active될 때 조금 커지는 것 같습니다. 수정해주시면 감사하겠습니다
  - PR에도 방금 달아놓은 내용이지만 버튼이 disabled 상태일 때는 `cursor: default`로 하면 좋을 것 같은데 다른 분들 의견은 어떠신가요?
 
