### PR TITLE
[BE] board 모듈 입력값 유효성 검증

### DIFF
--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -9,6 +9,8 @@ import {
 	Query,
 	UseInterceptors,
 	UploadedFile,
+	UsePipes,
+	ValidationPipe,
 } from '@nestjs/common';
 import { BoardService } from './board.service';
 import { CreateBoardDto } from './dto/create-board.dto';
@@ -32,6 +34,7 @@ export class BoardController {
 	constructor(private readonly boardService: BoardService) {}
 
 	@Post()
+	@UsePipes(ValidationPipe)
 	@ApiOperation({ summary: '게시글 작성', description: '게시글을 작성합니다.' })
 	@ApiCreatedResponse({ status: 201, description: '게시글 작성 성공' })
 	@ApiBadRequestResponse({
@@ -132,6 +135,7 @@ export class BoardController {
 	}
 
 	@Post(':id/image')
+	@UseInterceptors(FileInterceptor('file', { dest: './uploads' }))
 	@ApiOperation({
 		summary: '이미지 파일 업로드',
 		description: '이미지 파일을 업로드합니다.',
@@ -143,7 +147,6 @@ export class BoardController {
 		description: '잘못된 요청으로 파일 업로드 실패',
 	})
 	@ApiNotFoundResponse({ status: 404, description: '게시글이 존재하지 않음' })
-	@UseInterceptors(FileInterceptor('file', { dest: './uploads' }))
 	uploadFile(
 		@Param('id') board_id: string,
 		@UploadedFile() file: CreateImageDto,

--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -38,8 +38,8 @@ export class BoardController {
 		status: 400,
 		description: '잘못된 요청으로 게시글 작성 실패',
 	})
-	create(@Body() createBoardDto: CreateBoardDto): Promise<Board> {
-		return this.boardService.create(createBoardDto);
+	createBoard(@Body() createBoardDto: CreateBoardDto): Promise<Board> {
+		return this.boardService.createBoard(createBoardDto);
 	}
 
 	@Get()

--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -11,6 +11,7 @@ import {
 	UploadedFile,
 	UsePipes,
 	ValidationPipe,
+	ParseIntPipe,
 } from '@nestjs/common';
 import { BoardService } from './board.service';
 import { CreateBoardDto } from './dto/create-board.dto';
@@ -80,8 +81,8 @@ export class BoardController {
 		status: 404,
 		description: '게시글이 존재하지 않음',
 	})
-	findBoardById(@Param('id') id: string): Promise<Board> {
-		return this.boardService.findBoardById(+id);
+	findBoardById(@Param('id', ParseIntPipe) id: number): Promise<Board> {
+		return this.boardService.findBoardById(id);
 	}
 
 	@Patch(':id')
@@ -92,8 +93,11 @@ export class BoardController {
 		status: 400,
 		description: '잘못된 요청으로 게시글 수정 실패',
 	})
-	updateBoard(@Param('id') id: string, @Body() updateBoardDto: UpdateBoardDto) {
-		return this.boardService.updateBoard(+id, updateBoardDto);
+	updateBoard(
+		@Param('id', ParseIntPipe) id: number,
+		@Body() updateBoardDto: UpdateBoardDto,
+	) {
+		return this.boardService.updateBoard(id, updateBoardDto);
 	}
 
 	@Patch(':id/like')
@@ -106,8 +110,8 @@ export class BoardController {
 		status: 400,
 		description: '잘못된 요청으로 게시글 좋아요 실패',
 	})
-	patchLike(@Param('id') id: string): Promise<Partial<Board>> {
-		return this.boardService.patchLike(+id);
+	patchLike(@Param('id', ParseIntPipe) id: number): Promise<Partial<Board>> {
+		return this.boardService.patchLike(id);
 	}
 
 	@Patch(':id/unlike')
@@ -120,8 +124,8 @@ export class BoardController {
 		status: 400,
 		description: '잘못된 요청으로 게시글 좋아요 취소 실패',
 	})
-	patchUnlike(@Param('id') id: string): Promise<Partial<Board>> {
-		return this.boardService.patchUnlike(+id);
+	patchUnlike(@Param('id', ParseIntPipe) id: number): Promise<Partial<Board>> {
+		return this.boardService.patchUnlike(id);
 	}
 
 	@Delete(':id')
@@ -131,8 +135,8 @@ export class BoardController {
 		status: 404,
 		description: '게시글이 존재하지 않음',
 	})
-	deleteBoard(@Param('id') id: string): Promise<void> {
-		return this.boardService.deleteBoard(+id);
+	deleteBoard(@Param('id', ParseIntPipe) id: number): Promise<void> {
+		return this.boardService.deleteBoard(id);
 	}
 
 	@Post(':id/image')
@@ -149,9 +153,9 @@ export class BoardController {
 	})
 	@ApiNotFoundResponse({ status: 404, description: '게시글이 존재하지 않음' })
 	uploadFile(
-		@Param('id') board_id: string,
+		@Param('id', ParseIntPipe) board_id: number,
 		@UploadedFile() file: CreateImageDto,
 	): Promise<Board> {
-		return this.boardService.uploadFile(+board_id, file);
+		return this.boardService.uploadFile(board_id, file);
 	}
 }

--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -85,6 +85,7 @@ export class BoardController {
 	}
 
 	@Patch(':id')
+	@UsePipes(ValidationPipe)
 	@ApiOperation({ summary: '게시글 수정', description: '게시글을 수정합니다.' })
 	@ApiOkResponse({ status: 200, description: '게시글 수정 성공' })
 	@ApiBadRequestResponse({

--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -141,6 +141,7 @@ export class BoardController {
 
 	@Post(':id/image')
 	@UseInterceptors(FileInterceptor('file', { dest: './uploads' }))
+	@UsePipes(ValidationPipe)
 	@ApiOperation({
 		summary: '이미지 파일 업로드',
 		description: '이미지 파일을 업로드합니다.',

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -22,7 +22,7 @@ export class BoardService {
 		private readonly imageRepository: Repository<Image>,
 	) {}
 
-	async create(createBoardDto: CreateBoardDto): Promise<Board> {
+	async createBoard(createBoardDto: CreateBoardDto): Promise<Board> {
 		const { title, content, author } = createBoardDto;
 
 		const board = this.boardRepository.create({

--- a/packages/server/src/board/dto/create-board.dto.ts
+++ b/packages/server/src/board/dto/create-board.dto.ts
@@ -1,6 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Max, MaxLength } from 'class-validator';
 
 export class CreateBoardDto {
+	@IsNotEmpty({ message: '게시글 제목은 필수 입력입니다.' })
+	@IsString({ message: '게시글 제목은 문자열로 입력해야 합니다.' })
+	@MaxLength(255, { message: '게시글 제목은 255자 이내로 입력해야 합니다.' })
 	@ApiProperty({
 		description: '게시글 제목',
 		example: 'test title',
@@ -8,6 +12,8 @@ export class CreateBoardDto {
 	})
 	title: string;
 
+	@IsNotEmpty({ message: '게시글 내용은 필수 입력입니다.' })
+	@IsString({ message: '게시글 내용은 문자열로 입력해야 합니다.' })
 	@ApiProperty({
 		description: '게시글 내용',
 		example: 'test content',
@@ -15,6 +21,9 @@ export class CreateBoardDto {
 	})
 	content: string;
 
+	@IsNotEmpty({ message: '게시글 작성자는 필수 입력입니다.' })
+	@IsString({ message: '게시글 작성자는 문자열로 입력해야 합니다.' })
+	@MaxLength(50, { message: '게시글 작성자는 50자 이내로 입력해야 합니다.' })
 	@ApiProperty({
 		description: '게시글 작성자',
 		example: 'test author',

--- a/packages/server/src/board/dto/create-image.dto.ts
+++ b/packages/server/src/board/dto/create-image.dto.ts
@@ -1,10 +1,38 @@
+import { IsInt, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
 export class CreateImageDto {
+	@IsNotEmpty({ message: 'fieldname이 누락되었습니다.' })
+	@IsString({ message: 'fieldname은 문자열로 입력해야 합니다.' })
 	fieldname: string;
+
+	@IsNotEmpty({ message: 'originalname이 누락되었습니다.' })
+	@IsString({ message: 'originalname은 문자열로 입력해야 합니다.' })
 	originalname: string;
+
+	@IsNotEmpty({ message: 'encoding이 누락되었습니다.' })
+	@IsString({ message: 'encoding은 문자열로 입력해야 합니다.' })
 	encoding: string;
+
+	@IsNotEmpty({ message: 'mimetype이 누락되었습니다.' })
+	@IsString({ message: 'mimetype은 문자열로 입력해야 합니다.' })
+	@MaxLength(50, { message: 'mimetype은 50자 이내로 입력해야 합니다.' })
 	mimetype: string;
+
+	@IsNotEmpty({ message: 'destination이 누락되었습니다.' })
+	@IsString({ message: 'destination은 문자열로 입력해야 합니다.' })
 	destination: string;
+
+	@IsNotEmpty({ message: 'filename이 누락되었습니다.' })
+	@IsString({ message: 'filename은 문자열로 입력해야 합니다.' })
+	@MaxLength(50, { message: 'filename은 50자 이내로 입력해야 합니다.' })
 	filename: string;
+
+	@IsNotEmpty({ message: 'path가 누락되었습니다.' })
+	@IsString({ message: 'path는 문자열로 입력해야 합니다.' })
+	@MaxLength(50, { message: 'path는 50자 이내로 입력해야 합니다.' })
 	path: string;
+
+	@IsNotEmpty({ message: 'size가 누락되었습니다.' })
+	@IsInt({ message: 'size는 숫자로 입력해야 합니다.' })
 	size: number;
 }


### PR DESCRIPTION
### 📎 이슈번호

#88 [06-14] 서버는 사용자 요청에 따라 본인이 작성한 게시글을 수정한다. 
#60 [08-06] 서버는 전송 받은 글 데이터를 데이터베이스에 저장한다. 
#61 [08-07] 사진 정보는 스토리지 서버에 저장한다. 

### 📃 변경사항

- [x] board 모듈 입력값 유효성 검증
  - [x] POST /board
  - [x] ParseIntPipe로 id 타입 int로 변경
  - [x] PATCH /board/:id
  - [x] POST /board/:id/image

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

#### POST /board 결과화면

<img width="710" alt="스크린샷 2023-11-21 오후 10 55 31" src="https://user-images.githubusercontent.com/138586629/284601143-f2d4e27d-13e6-4337-b4b1-3d61c35102d0.png">

#### ParseIntPipe 결과화면

<img width="690" alt="스크린샷 2023-11-21 오후 11 10 00" src="https://user-images.githubusercontent.com/138586629/284605714-bb8f7027-4c48-463c-8e6d-b13dec9421c6.png">

### 💫 기타사항

- 개발 기록
  - [[재하] 1121(화) 개발기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%9E%AC%ED%95%98%5D-1121(%ED%99%94)-%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D)
