### PR TITLE
[FE] Toast 컴포넌트 구현

### DIFF
--- a/packages/client/src/shared/ui/inputBar/InputBar.tsx
+++ b/packages/client/src/shared/ui/inputBar/InputBar.tsx
@@ -31,7 +31,7 @@ const Input = styled.input`
 	height: 100%;
 	padding: 12px;
 	border-radius: 4px;
-	background-color: ${theme.colors.background['bdp-03']};
+	background-color: ${theme.colors.background.bdp03};
 	border: 1px solid ${theme.colors.stroke.default};
 	color: ${theme.colors.text.third};
 

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -11,7 +11,7 @@ interface PropsTypes {
 export default function Toast({ children }: PropsTypes) {
 	const [visible, setVisible] = useState(true);
 
-	setTimeout(() => setVisible(false), 3000);
+	setTimeout(() => setVisible(false), 2000);
 
 	if (!visible) return null;
 

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { Body04BD } from '../styles';
+import confirmIcon from '../../../../public/icons/icon-confirm-22.svg';
+
+interface PropsTypes {
+	children: string;
+}
+
+export default function Toast({ children }: PropsTypes) {
+	return (
+		<Layout>
+			<img src={confirmIcon} alt="체크 아이콘" />
+			<Text>{children}</Text>
+		</Layout>
+	);
+}
+
+const Layout = styled.div`
+	display: flex;
+	background-color: ${({ theme }) => theme.colors.primary.filled};
+	padding: 16px 24px;
+	border-radius: 27px;
+`;
+
+const Text = styled.p`
+	color: #fff;
+	margin: 0 0 0 8px;
+	${Body04BD}
+`;

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -1,12 +1,20 @@
 import styled from '@emotion/styled';
 import { Body04BD } from '../styles';
 import confirmIcon from '../../../../public/icons/icon-confirm-22.svg';
+import { useState } from 'react';
+import { keyframes } from '@emotion/react';
 
 interface PropsTypes {
 	children: string;
 }
 
 export default function Toast({ children }: PropsTypes) {
+	const [visible, setVisible] = useState(true);
+
+	setTimeout(() => setVisible(false), 3000);
+
+	if (!visible) return null;
+
 	return (
 		<Layout>
 			<img src={confirmIcon} alt="체크 아이콘" />
@@ -15,11 +23,23 @@ export default function Toast({ children }: PropsTypes) {
 	);
 }
 
+const fadeOutAnimation = keyframes`
+	from { opacity: 1 }
+  to { opacity: 0 }
+`;
+
 const Layout = styled.div`
 	display: flex;
-	background-color: ${({ theme }) => theme.colors.primary.filled};
+	position: absolute;
+	top: 53px;
+	left: 50%;
+	transform: translate(-50%, 0%);
 	padding: 16px 24px;
 	border-radius: 27px;
+	background-color: ${({ theme }) => theme.colors.primary.filled};
+
+	animation: ${fadeOutAnimation} 2s ease forwards;
+	animation-delay: 2s;
 `;
 
 const Text = styled.p`

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -34,6 +34,7 @@ const Layout = styled.div`
 	top: 53px;
 	left: 50%;
 	transform: translate(-50%, 0%);
+	z-index: 1000;
 	padding: 16px 24px;
 	border-radius: 40px;
 	background-color: ${({ theme }) => theme.colors.primary.filled};

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -11,7 +11,7 @@ interface PropsTypes {
 export default function Toast({ children }: PropsTypes) {
 	const [visible, setVisible] = useState(true);
 
-	setTimeout(() => setVisible(false), 2000);
+	setTimeout(() => setVisible(false), 3000);
 
 	if (!visible) return null;
 
@@ -35,10 +35,10 @@ const Layout = styled.div`
 	left: 50%;
 	transform: translate(-50%, 0%);
 	padding: 16px 24px;
-	border-radius: 27px;
+	border-radius: 40px;
 	background-color: ${({ theme }) => theme.colors.primary.filled};
 
-	animation: ${fadeOutAnimation} 2s ease forwards;
+	animation: ${fadeOutAnimation} 1s ease forwards;
 	animation-delay: 2s;
 `;
 


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- Toast 컴포넌트를 구현했습니다.
- props는 토스트의 텍스트를 받는 children 하나만 있습니다.
- 2초가 지나면 자연스럽게 사라집니다.
  - keyframe 부분 코드만 있어도 동작화면은 같습니다. 
  - visible이라는 useState를 만들고 setTime을 사용한 이유는 아래와 같습니다.
  - `visible:none`으로만 처리하지 않고 아예 없애버리고 싶어서 3초가 지나면 컴포넌트가 null을 리턴하도록 했습니다. 
  - 다른 분들의 의견도 궁금하네요.
  - animation duration이 2초인데 setTimeout이 3초인 이유는, 사라지는 animation이 1초간 지속되기 때문입니다. 
  - setTimout에 2초를 주면 애니메이션이 시작되기 전에 null을 리턴해서 애니메이션이 안보입니다 🥹
- `position: absolute`를 주어 위치를 고정했습니다. 

### 📌 중점적으로 볼 부분
setTimeout 부분

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/22b69d45-6c74-4d63-af9f-9c037b7de6a0

### 💫 기타사항
솔직히 토스트좀 귀여운것같아요 