### PR TITLE
[BE] SignOut시 토큰 제거

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import {
 } from '@nestjs/swagger';
 import { JwtEnum } from './enums/jwt.enum';
 import { CookieAuthGuard } from './cookie-auth.guard';
+import { UserEnum } from './enums/user.enum';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -76,9 +77,15 @@ export class AuthController {
 	@ApiOkResponse({ status: 200, description: '로그아웃 성공' })
 	async signOut(@Res({ passthrough: true }) res: Response, @Req() req) {
 		await this.authService.signOut(req.user);
-		res.clearCookie('accessToken', { path: '/', httpOnly: true });
-		res.clearCookie('refreshToken', { path: '/', httpOnly: true });
-		return { message: 'success' };
+		res.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, {
+			path: '/',
+			httpOnly: true,
+		});
+		res.clearCookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, {
+			path: '/',
+			httpOnly: true,
+		});
+		return { message: UserEnum.SUCCESS_SIGNOUT_MESSAGE };
 	}
 
 	@Get('is-available-username')

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -8,6 +8,8 @@ import {
 	Query,
 	UsePipes,
 	ValidationPipe,
+	UseGuards,
+	Req,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignUpUserDto } from './dto/signup-user.dto';
@@ -24,6 +26,7 @@ import {
 	ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { JwtEnum } from './enums/jwt.enum';
+import { CookieAuthGuard } from './cookie-auth.guard';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -68,10 +71,13 @@ export class AuthController {
 	}
 
 	@Get('signout')
+	@UseGuards(CookieAuthGuard)
 	@ApiOperation({ summary: '로그아웃', description: '로그아웃을 진행합니다.' })
 	@ApiOkResponse({ status: 200, description: '로그아웃 성공' })
-	async signOut(@Res({ passthrough: true }) res: Response) {
+	async signOut(@Res({ passthrough: true }) res: Response, @Req() req) {
+		await this.authService.signOut(req.user);
 		res.clearCookie('accessToken', { path: '/', httpOnly: true });
+		res.clearCookie('refreshToken', { path: '/', httpOnly: true });
 		return { message: 'success' };
 	}
 

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -66,6 +66,10 @@ export class AuthService {
 		return { accessToken, refreshToken };
 	}
 
+	async signOut(user: Partial<User>) {
+		this.redisRepository.del(user.username);
+	}
+
 	async isAvailableUsername(username: string): Promise<boolean> {
 		if (!username) {
 			throw new BadRequestException('username is required');

--- a/packages/server/src/auth/cookie-auth.guard.ts
+++ b/packages/server/src/auth/cookie-auth.guard.ts
@@ -66,7 +66,6 @@ export class CookieAuthGuard extends AuthGuard('jwt') {
 			JwtEnum.ACCESS_TOKEN_TYPE,
 			this.jwtService,
 		);
-		console.log(newAccessToken);
 		response.cookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, newAccessToken, {
 			path: '/',
 			httpOnly: true,

--- a/packages/server/src/auth/enums/user.enum.ts
+++ b/packages/server/src/auth/enums/user.enum.ts
@@ -19,4 +19,6 @@ export enum UserEnum {
 	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}자여야 합니다.`,
 
 	FAIL_SIGNIN_MESSAGE = '아이디에 해당하는 회원이 존재하지 않거나 비밀번호가 일치하지 않습니다.',
+
+	SUCCESS_SIGNOUT_MESSAGE = '로그아웃에 성공했습니다.',
 }

--- a/packages/server/src/auth/redis.repository.ts
+++ b/packages/server/src/auth/redis.repository.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { redisConfig } from '../config/redis.config';
 
 @Injectable()
@@ -16,6 +16,10 @@ export class RedisRepository {
 
 	async set(key: string, value: string) {
 		return this.redisClient.set(key, value);
+	}
+
+	async del(key: string) {
+		return this.redisClient.del(key);
 	}
 
 	async checkRefreshToken(username: string, refreshToken: string) {


### PR DESCRIPTION
### 📎 이슈번호

#35 [05-04] 로그인을 한 사용자라면 Redis의 Refresh Token 정보를 삭제한다.

### 📃 변경사항

- RedisController에 del 메서드 추가
- AuthController의 signout api에 CookieAuthGuard 추가
- authService.signout으로 req.user 정보 넘김
- Redis의 키값을 삭제하는 authService.signout 메서드 작성
- AuthController signout 로직에 enum 적용

### 📌 중점적으로 볼 부분

일단 enum을 사용하여 해놓긴 했는데 재하님이 저번에 말씀해주신 것처럼 어디까지 enum을 사용할 것인지는 저희끼리 합의가 필요할 듯 싶습니다!

[개발 기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%A4%80%EC%84%AD%5D-1122(%EC%88%98)-%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D-%E2%80%90-SignOut%EC%8B%9C-%ED%86%A0%ED%81%B0-%EC%A0%9C%EA%B1%B0)

### 🎇 동작 화면

## 로그인 하지 않은 경우 (쿠키에 토큰이 없거나 유효하지 않은 경우)

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/1fc35a22-f211-45a4-ba2f-f0aacc651d0d)

## 로그인 한 경우 (쿠키의 토큰이 유효한 경우)

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/e8181952-0b98-40fb-a3e8-a800f775e2be)

### 💫 기타사항
