### PR TITLE
[FE] 닉네임 설정 모달 구현 

### DIFF
--- a/packages/client/src/widgets/nickNameSetModal/NickNameSetModal.tsx
+++ b/packages/client/src/widgets/nickNameSetModal/NickNameSetModal.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import { Button, Modal } from 'shared/ui';
+import InputBar from 'shared/ui/inputBar/InputBar';
+import { useState } from 'react';
+
+export default function NickNameSetModal() {
+	const [nickName, setNickName] = useState('');
+
+	const handleSaveButton = () => {
+		if (!nickName) return;
+
+		console.log(nickName);
+		// TODO: 백엔드 요청 보낸 후 로그인 모달로 이동
+	};
+
+	const handleNickNameInput = ({
+		target,
+	}: React.ChangeEvent<HTMLInputElement>) => setNickName(target.value);
+
+	const saveButton = (
+		<Button
+			onClick={handleSaveButton}
+			buttonType="CTA-icon"
+			size="m"
+			disabled={!nickName}
+		>
+			저장
+		</Button>
+	);
+
+	return (
+		<Modal title="회원가입" rightButton={saveButton}>
+			<InputBarWrapper>
+				<InputBar
+					id="nickName"
+					label="닉네임"
+					placeholder="닉네임을 입력해주세요."
+					isEssential
+					onChange={handleNickNameInput}
+				/>
+			</InputBarWrapper>
+		</Modal>
+	);
+}
+
+const InputBarWrapper = styled.div`
+	width: 452px;
+`;

--- a/packages/client/src/widgets/signupModal/SignUpModal.tsx
+++ b/packages/client/src/widgets/signupModal/SignUpModal.tsx
@@ -3,7 +3,7 @@ import { Button, Modal } from 'shared/ui';
 import InputBar from 'shared/ui/inputBar/InputBar';
 import { useState } from 'react';
 
-export default function SignUpModal() {
+export default function signUpModal() {
 	const [isAllInputFilled, setIsAllInputFilled] = useState(false);
 
 	const [inputValues, setInputValues] = useState({
@@ -16,7 +16,7 @@ export default function SignUpModal() {
 		// TODO: 로그인 모달로 이동하도록 하기
 	};
 
-	const handleSignUpButton = () => {
+	const handlesignUpButton = () => {
 		if (!isAllInputFilled) return;
 
 		console.log(inputValues);
@@ -43,16 +43,12 @@ export default function SignUpModal() {
 		});
 	};
 
-	const signupButton = isAllInputFilled ? (
-		<Button onClick={handleSignUpButton} buttonType="CTA-icon" size="m">
-			회원가입
-		</Button>
-	) : (
+	const signUpButton = (
 		<Button
-			onClick={handleSignUpButton}
+			onClick={handlesignUpButton}
 			buttonType="CTA-icon"
 			size="m"
-			disabled
+			disabled={!isAllInputFilled}
 		>
 			회원가입
 		</Button>
@@ -61,7 +57,7 @@ export default function SignUpModal() {
 	return (
 		<Modal
 			title="회원가입"
-			rightButton={signupButton}
+			rightButton={signUpButton}
 			onClickGoBack={handleGoBackButton}
 		>
 			<InputBarsContainer>


### PR DESCRIPTION
### 📎 이슈번호
#8 

### 📃 변경사항
- 회원가입 모달과 거의 같은 형식으로 닉네임 설정 모달을 만들었습니다. 
- input이 채워졌을 경우만 버튼이 활성화됩니다.
- SignUpModa의 signUpButton 부분 코드를 더 간단하게 바꾸었습니다.

### 📌 중점적으로 볼 부분
NickNameSetModal

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/502a1a9f-cfea-4071-bf8d-70a5cf35751f

### 💫 기타사항
혹시 회원가입 모달 PR을 아직 안보셨다면 그것부터 봐주세요 