### PR TITLE
[FE] 모달창 자식요소 투명해지는 문제 해결

### DIFF
--- a/packages/client/src/shared/ui/modals/Modal.tsx
+++ b/packages/client/src/shared/ui/modals/Modal.tsx
@@ -71,13 +71,12 @@ const MainLayout = styled.div`
 	display: flex;
 	flex-direction: column;
 	border-radius: 16px;
-	opacity: 80%;
 	padding: 32px;
 	margin: 12px 0 0 0;
 
 	${({ theme: { colors } }) => css`
-		background-color: ${colors.background.bdp01};
-		border: 2px solid ${colors.stroke.focus};
+		background-color: ${colors.background.bdp01_80};
+		border: 2px solid ${colors.stroke.focus_80};
 	`};
 `;
 

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -51,13 +51,12 @@ const Layout = styled.div`
 	align-items: center;
 	width: 100%;
 	border-radius: 8px;
-	opacity: 90%;
 	padding: 8px;
-	background-color: ${({ theme: { colors } }) => colors.background.bdp01};
+	background-color: ${({ theme: { colors } }) => colors.background.bdp01_80};
 	border: 1px solid ${({ theme: { colors } }) => colors.stroke.default};
 
 	:hover {
-		border: 1px solid ${({ theme: { colors } }) => colors.stroke.focus};
+		border: 1px solid ${({ theme: { colors } }) => colors.stroke.focus_80};
 	}
 `;
 

--- a/packages/client/src/shared/ui/styles/theme.ts
+++ b/packages/client/src/shared/ui/styles/theme.ts
@@ -24,11 +24,13 @@ const theme = {
 			bdp01: '#05021F',
 			bdp02: '#161335',
 			bdp03: '#241F50',
+			bdp01_80: '#05021FCC',
 		},
 
 		stroke: {
 			default: '#1E1A4D',
 			focus: '#6C55FA',
+			focus_80: '#6C55FACC',
 			sc: '#514B75',
 		},
 


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 투명도를 준 색상코드를 theme.ts에 추가했습니다.
  - [참고 링크](https://mong-blog.tistory.com/entry/CSS-hex-%EC%BB%AC%EB%9F%AC%EC%97%90-%ED%88%AC%EB%AA%85%EB%8F%84%EB%A5%BC-2%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95)
  - bdp01 색상에 80의 투명도가 들어간 경우 bdp01_80과 같은 이름으로 설정했습니다. 앞으로 투명도가 필요한 색상코드가 있다면 모두 이런 형식으로 추가해주시면 될 것 같습니다.
- Modal과 Search의 Layout opacity를 없애고, background-color를 투명도 준 색상으로 변경했습니다.

### 🫨 고민한 부분
- opacity를 줄 경우 해당 요소의 자식 요소들까지 모두 투명해지는 문제가 있었습니다.
  - opacity를 주지 않고, background color에 투명도가 적용된 색상이 적용된다면 그 요소에만 투명도가 적용됩니다.

### 📌 중점적으로 볼 부분

### 🎇 동작 화면
뒷배경의 색상과 관계없이 input의 색은 유지되는 것을 볼 수 있습니다.


![image](https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/c1c5d6d9-d862-484f-b49b-58e85fcff8a0)
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/e986a50f-30e5-4b58-8ca7-e05e80fd3e12)


### 💫 기타사항
