### PR TITLE
[BE] 네이버 로그인 구현

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -146,13 +146,14 @@ export class AuthController {
 		res.redirect(redirectUrl);
 	}
 
-	@Get('github/callback')
+	@Get(':service/callback')
 	async oauthGithubCallback(
+		@Param('service') service: string,
 		@Query('code') authorizedCode: string,
 		@Res({ passthrough: true }) res: Response,
 	) {
 		const { username, accessToken, refreshToken } =
-			await this.authService.oauthGithubCallback(authorizedCode);
+			await this.authService.oauthCallback(service, authorizedCode);
 
 		if (username) {
 			res.cookie('GitHubUsername', username, {
@@ -174,8 +175,9 @@ export class AuthController {
 		return { accessToken, refreshToken };
 	}
 
-	@Post('github/signup')
+	@Post(':service/signup')
 	async signUpWithGithub(
+		@Param('service') service: string,
 		@Body('nickname') nickname: string,
 		@Req() req,
 		@Res({ passthrough: true }) res: Response,
@@ -188,6 +190,7 @@ export class AuthController {
 		}
 
 		const savedUser = await this.authService.signUpWithGithub(
+			service,
 			nickname,
 			gitHubUsername,
 		);

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -150,13 +150,14 @@ export class AuthController {
 	async oauthGithubCallback(
 		@Param('service') service: string,
 		@Query('code') authorizedCode: string,
+		@Query('state') state: string,
 		@Res({ passthrough: true }) res: Response,
 	) {
 		const { username, accessToken, refreshToken } =
-			await this.authService.oauthCallback(service, authorizedCode);
+			await this.authService.oauthCallback(service, authorizedCode, state);
 
 		if (username) {
-			res.cookie('GitHubUsername', username, {
+			res.cookie(`${service}Username`, username, {
 				path: '/',
 				httpOnly: true,
 			});

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -11,6 +11,8 @@ import {
 	UseGuards,
 	Req,
 	UnauthorizedException,
+	Param,
+	NotFoundException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignUpUserDto } from './dto/signup-user.dto';
@@ -125,11 +127,23 @@ export class AuthController {
 		return this.authService.isAvailableNickname(nickname);
 	}
 
-	@Get('github/signin')
-	signInWithGithub(@Res({ passthrough: true }) res: Response) {
-		res.redirect(
-			`https://github.com/login/oauth/authorize?client_id=${process.env.OAUTH_GITHUB_CLIENT_ID}&scope=read:user%20user:email`,
-		);
+	@Get(':service/signin')
+	signInWithOAuth(
+		@Param('service') service: string,
+		@Res({ passthrough: true }) res: Response,
+	) {
+		let redirectUrl: string;
+		switch (service) {
+			case 'github':
+				redirectUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.OAUTH_GITHUB_CLIENT_ID}&scope=read:user%20user:email`;
+				break;
+			case 'naver':
+				redirectUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URI}&state=STATE_STRING`;
+				break;
+			default:
+				throw new NotFoundException('존재하지 않는 서비스입니다.');
+		}
+		res.redirect(redirectUrl);
 	}
 
 	@Get('github/callback')

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -138,7 +138,7 @@ export class AuthController {
 				redirectUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.OAUTH_GITHUB_CLIENT_ID}&scope=read:user%20user:email`;
 				break;
 			case 'naver':
-				redirectUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URI}&state=STATE_STRING`;
+				redirectUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URL}&state=STATE_STRING`;
 				break;
 			default:
 				throw new NotFoundException('존재하지 않는 서비스입니다.');
@@ -147,7 +147,7 @@ export class AuthController {
 	}
 
 	@Get(':service/callback')
-	async oauthGithubCallback(
+	async oauthCallback(
 		@Param('service') service: string,
 		@Query('code') authorizedCode: string,
 		@Query('state') state: string,
@@ -177,26 +177,26 @@ export class AuthController {
 	}
 
 	@Post(':service/signup')
-	async signUpWithGithub(
+	async signUpWithOAuth(
 		@Param('service') service: string,
 		@Body('nickname') nickname: string,
 		@Req() req,
 		@Res({ passthrough: true }) res: Response,
 	) {
-		let gitHubUsername;
+		let resourceServerUsername: string;
 		try {
-			gitHubUsername = req.cookies.GitHubUsername;
+			resourceServerUsername = req.cookies[`${service}Username`];
 		} catch (e) {
 			throw new UnauthorizedException('잘못된 접근입니다.');
 		}
 
-		const savedUser = await this.authService.signUpWithGithub(
+		const savedUser = await this.authService.signUpWithOAuth(
 			service,
 			nickname,
-			gitHubUsername,
+			resourceServerUsername,
 		);
 
-		res.clearCookie('GitHubUsername', {
+		res.clearCookie(`${service}Username`, {
 			path: '/',
 			httpOnly: true,
 		});

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -103,7 +103,7 @@ export class AuthService {
 		}
 	}
 
-	async oauthCallback(service: string, authorizedCode: string) {
+	async oauthCallback(service: string, authorizedCode: string, state?: string) {
 		if (!authorizedCode) {
 			throw new BadRequestException('Authorized Code가 존재하지 않습니다.');
 		}
@@ -111,6 +111,7 @@ export class AuthService {
 		const resourceServerAccessToken = await getOAuthAccessToken(
 			service,
 			authorizedCode,
+			state,
 		);
 		const resourceServerUser = await getOAuthUserData(
 			service,

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -148,27 +148,32 @@ export class AuthService {
 		};
 	}
 
-	async signUpWithGithub(
+	async signUpWithOAuth(
 		service: string,
 		nickname: string,
-		GitHubUsername: any,
+		resourceServerUsername: any,
 	) {
-		let gitHubUserData;
+		let recivedResourceServerUsername: string;
 		try {
-			const gitHubAccessToken = await this.redisRepository.get(GitHubUsername);
-			gitHubUserData = await getOAuthUserData(service, gitHubAccessToken);
+			const resourceServerAccessToken: string = await this.redisRepository.get(
+				resourceServerUsername,
+			);
+			recivedResourceServerUsername = await getOAuthUserData(
+				service,
+				resourceServerAccessToken,
+			);
 		} catch (e) {
 			throw new UnauthorizedException('잘못된 접근입니다.');
 		}
 
-		if (gitHubUserData.username !== GitHubUsername) {
+		if (recivedResourceServerUsername !== resourceServerUsername) {
 			throw new UnauthorizedException('잘못된 접근입니다.');
 		}
 
-		this.redisRepository.del(GitHubUsername);
+		this.redisRepository.del(resourceServerUsername);
 
-		const newUser = this.authRepository.create({
-			username: GitHubUsername,
+		const newUser: User = this.authRepository.create({
+			username: resourceServerUsername,
 			password: uuid(),
 			nickname,
 		});

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -113,22 +113,22 @@ export class AuthService {
 			authorizedCode,
 			state,
 		);
-		const resourceServerUser = await getOAuthUserData(
+		const resourceServerUsername = await getOAuthUserData(
 			service,
 			resourceServerAccessToken,
 		);
 
 		const user = await this.authRepository.findOneBy({
-			username: resourceServerUser.username,
+			username: resourceServerUsername,
 		});
 
 		if (!user) {
 			this.redisRepository.set(
-				resourceServerUser.username,
+				resourceServerUsername,
 				resourceServerAccessToken,
 			);
 			return {
-				username: resourceServerUser.username,
+				username: resourceServerUsername,
 				accessToken: null,
 				refreshToken: null,
 			};

--- a/packages/server/src/utils/auth.util.ts
+++ b/packages/server/src/utils/auth.util.ts
@@ -20,7 +20,10 @@ export async function createJwt(
 	return jwt;
 }
 
-export async function getGitHubAccessToken(authorizedCode: string) {
+export async function getOAuthAccessToken(
+	service: string,
+	authorizedCode: string,
+) {
 	const accessTokenResponse = await fetch(
 		'https://github.com/login/oauth/access_token',
 		{
@@ -47,7 +50,7 @@ export async function getGitHubAccessToken(authorizedCode: string) {
 	return accessTokenData.access_token;
 }
 
-export async function getGitHubUserData(accessToken: string) {
+export async function getOAuthUserData(service: string, accessToken: string) {
 	const userResponse = await fetch('https://api.github.com/user', {
 		method: 'GET',
 		headers: {

--- a/packages/server/src/utils/auth.util.ts
+++ b/packages/server/src/utils/auth.util.ts
@@ -59,9 +59,14 @@ export async function getOAuthUserData(service: string, accessToken: string) {
 	}
 
 	const userData = await userResponse.json();
-	return {
-		username: userData.login,
-	};
+	switch (service) {
+		case 'github':
+			return userData.login;
+		case 'naver':
+			return userData.response.id;
+		default:
+			throw new NotFoundException('존재하지 않는 서비스입니다.');
+	}
 }
 
 function getOAuthAccessTokenRequestData(

--- a/packages/server/src/utils/auth.util.ts
+++ b/packages/server/src/utils/auth.util.ts
@@ -37,7 +37,7 @@ export async function getOAuthAccessToken(
 
 	if (!accessTokenResponse.ok) {
 		throw new InternalServerErrorException(
-			'GitHub으로부터 accessToken을 받아오지 못했습니다.',
+			`${service}으로부터 accessToken을 받아오지 못했습니다.`,
 		);
 	}
 
@@ -46,16 +46,15 @@ export async function getOAuthAccessToken(
 }
 
 export async function getOAuthUserData(service: string, accessToken: string) {
-	const userResponse = await fetch('https://api.github.com/user', {
-		method: 'GET',
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-		},
-	});
+	const [urlForUserData, requestData] = getOAuthUserDataRequestData(
+		service,
+		accessToken,
+	);
+	const userResponse = await fetch(urlForUserData, requestData);
 
 	if (!userResponse.ok) {
 		throw new InternalServerErrorException(
-			'GitHub으로부터 유저 정보를 받아오지 못했습니다.',
+			`${service}으로부터 유저 정보를 받아오지 못했습니다.`,
 		);
 	}
 
@@ -109,4 +108,32 @@ function getOAuthAccessTokenRequestData(
 			throw new NotFoundException('존재하지 않는 서비스입니다.');
 	}
 	return [urlForAccessToken, requestData];
+}
+
+function getOAuthUserDataRequestData(service: string, accessToken: string) {
+	let urlForUserData: string;
+	let requestData: any;
+	switch (service) {
+		case 'github':
+			urlForUserData = 'https://api.github.com/user';
+			requestData = {
+				method: 'GET',
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+			break;
+		case 'naver':
+			urlForUserData = 'https://openapi.naver.com/v1/nid/me';
+			requestData = {
+				method: 'GET',
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+			break;
+		default:
+			throw new NotFoundException('존재하지 않는 서비스입니다.');
+	}
+	return [urlForUserData, requestData];
 }


### PR DESCRIPTION
### 📎 이슈번호

- [03-06] 서버는 네이버로 로그인 기능을 제공한다. #106 

### 📃 변경사항

깃헙 로그인때 사용했던 부분을 리팩토링 해서 OAuth 로그인 로직으로 통합했습니다.
url에 :service로 @Param으로 서비스 명을 받아와서 해주는 식으로 함수 재사용을 최대한 하려고 했습니다.

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

naver에서 accessToken으로 유저 정보 가져오면 아래와 같이 id값이 uuid? 값이 나옵니다. 이걸 그냥 회원가입 하는데 username으로 썼습니다.
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/cf6d47c7-f161-4b02-85fd-49736e9c20a9)

`/auth/naver/signup`으로 회원가입 완료
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/faeed808-cbe8-45b1-b6e0-6c2d75aac03b)

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/bf64c285-8f6e-4645-8b5e-2c1014eff93c)

다음부터 네이버 로그인 하면 JWT 발급됨

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/69b11286-3a87-41ec-aff7-05f3454fa0b5)


### 💫 기타사항
