### PR TITLE
[BE] 구글 로그인 구현

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -138,7 +138,10 @@ export class AuthController {
 				redirectUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.OAUTH_GITHUB_CLIENT_ID}&scope=read:user%20user:email`;
 				break;
 			case 'naver':
-				redirectUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URL}&state=STATE_STRING`;
+				redirectUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URI}&state=STATE_STRING`;
+				break;
+			case 'google':
+				redirectUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.OAUTH_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.OAUTH_GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile`;
 				break;
 			default:
 				throw new NotFoundException('존재하지 않는 서비스입니다.');

--- a/packages/server/src/utils/auth.util.ts
+++ b/packages/server/src/utils/auth.util.ts
@@ -64,6 +64,8 @@ export async function getOAuthUserData(service: string, accessToken: string) {
 			return userData.login;
 		case 'naver':
 			return userData.response.id;
+		case 'google':
+			return userData.email;
 		default:
 			throw new NotFoundException('존재하지 않는 서비스입니다.');
 	}
@@ -109,6 +111,23 @@ function getOAuthAccessTokenRequestData(
 				}),
 			};
 			break;
+		case 'google':
+			urlForAccessToken = 'https://oauth2.googleapis.com/token';
+			requestData = {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: process.env.OAUTH_GOOGLE_CLIENT_ID,
+					client_secret: process.env.OAUTH_GOOGLE_CLIENT_SECRETS,
+					code: authorizedCode,
+					redirect_uri: process.env.OAUTH_GOOGLE_REDIRECT_URI,
+				}),
+			};
+			break;
 		default:
 			throw new NotFoundException('존재하지 않는 서비스입니다.');
 	}
@@ -130,6 +149,15 @@ function getOAuthUserDataRequestData(service: string, accessToken: string) {
 			break;
 		case 'naver':
 			urlForUserData = 'https://openapi.naver.com/v1/nid/me';
+			requestData = {
+				method: 'GET',
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+			break;
+		case 'google':
+			urlForUserData = 'https://www.googleapis.com/oauth2/v2/userinfo';
 			requestData = {
 				method: 'GET',
 				headers: {


### PR DESCRIPTION
### 📎 이슈번호

- [03-07] 서버는 구글로 로그인 기능을 제공한다. #105 

### 📃 변경사항

OAuth 재사용하게 코드 고쳐놓으니 개발이 아주 빨랐네요. 코드를 별로 고친게 없습니다 ㅎ
근데 재하님 그 이 각 서비스에 OAuth 클라이언트 만들 때 url을 localhost 버전이랑 저희 별글.site 버전 두 개를 만들어서 각각의 클라이언트 ID와 secret이 다릅니다.
그래서 로컬 환경이랑 프로덕션 환경 .env를 수정하긴 해야합니다!

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

google에서 accessToken으로 유저 정보 가져오면 아래와 같은 정보를 줍니다. 
이 중 email을 회원가입때 필요한 username으로 사용하였습니다.

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/1a62711f-09fd-4549-a8cc-5c18f4173322)

`/auth/google/signup`으로 쿠키에 googleUsername을 키로하여 이메일을 담고, 요청 body에 닉네임 정보를 담아 보내면 회원가입 완료

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/23d6db7b-9579-48fd-864c-eeaca938efbf)

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/59099911-a077-472c-9fa9-58fa13b6023d)

다음부터 구글 로그인 하면 JWT 발급됨

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/7cabea27-444d-43d5-ad7f-4aa6fedea252)

### 💫 기타사항
