### PR TITLE
[FE] Axios Interceptor 추가

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -6,11 +6,14 @@ import { RouterProvider } from 'react-router-dom';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'shared/ui/styles/theme';
 import './global.css';
+import { AxiosInterceptor } from 'shared/apis/AxiosInterceptor';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>
 		<ThemeProvider theme={theme}>
-			<RouterProvider router={router} />
+			<AxiosInterceptor>
+				<RouterProvider router={router} />
+			</AxiosInterceptor>
 		</ThemeProvider>
 	</React.StrictMode>,
 );

--- a/packages/client/src/shared/apis/AxiosInterceptor.ts
+++ b/packages/client/src/shared/apis/AxiosInterceptor.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+
+const instance = axios.create({
+	baseURL: 'https://www.별글.site/api/',
+});
+
+interface Props {
+	children: JSX.Element;
+}
+
+function AxiosInterceptor({ children }: Props) {
+	useEffect(() => {
+		const responseInterceptor = instance.interceptors.response.use(
+			(response) => {
+				return response;
+			},
+			(error) => {
+				console.error(error.response.data);
+				return Promise.reject(error);
+			},
+		);
+
+		const requestInterceptor = instance.interceptors.request.use(
+			(config) => {
+				return config;
+			},
+			(error) => {
+				console.error(error.response.data);
+				return Promise.reject(error);
+			},
+		);
+
+		return () => {
+			instance.interceptors.request.eject(requestInterceptor);
+			instance.interceptors.response.eject(responseInterceptor);
+		};
+	}, []);
+
+	return children;
+}
+
+export default instance;
+export { AxiosInterceptor };

--- a/packages/client/src/shared/apis/index.ts
+++ b/packages/client/src/shared/apis/index.ts
@@ -1,0 +1,2 @@
+export * from './AxiosInterceptor';
+export * from './signUp';

--- a/packages/client/src/shared/apis/signUp.ts
+++ b/packages/client/src/shared/apis/signUp.ts
@@ -1,0 +1,25 @@
+import instance from './AxiosInterceptor';
+
+interface PostSignUpTypes {
+	username: string;
+	password: string;
+	nickname: string;
+}
+
+export const postSignUp = async ({
+	username,
+	password,
+	nickname,
+}: PostSignUpTypes) => {
+	const { data } = await instance({
+		method: 'POST',
+		url: '/auth/signup',
+		data: {
+			username,
+			password,
+			nickname,
+		},
+	});
+
+	return data;
+};


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- Axios Interceptor 추가
  - then 또는 catch로 처리되기 전에 요청/응답을 가로챌 수 있습니다.
  - 아래와 같은 경우에 유용합니다.
  - 에러 핸들링
  - 로딩 처리
  - 헤더에 Authorization 미리 넣기
  - 등등...
- postSignUp부분 api 추가
  - 한 김에 api부분을 모두 처리하려 했으나...
  - 제가 닉네임 부분 UI를 까먹은 것을 알게되어...... ....

### 📌 중점적으로 볼 부분
- AxiosInterceptor 부분 코드 중 이상한게 있으면 코멘트주세용.
- 공통적으로 처리해야 할 로직이 있다면 저 코드에 추가해주시길바랍니다

### 💫 기타사항
닉네임 UI 추가할 생각하니 기쁨의눈물만나네요하하
