### PR TITLE
[FE] 글 조회 모달 구현

### DIFF
--- a/packages/client/src/entities/posts/ui/Post.tsx
+++ b/packages/client/src/entities/posts/ui/Post.tsx
@@ -4,29 +4,22 @@ import { useCameraStore } from 'shared/store/useCameraStore';
 import { ThreeEvent } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import styled from '@emotion/styled';
-import { useViewStore } from 'shared/store/useWritingStore';
+import { useViewStore } from 'shared/store/useViewStore';
 import * as THREE from 'three';
+import { PostData } from 'shared/lib/types/post';
+import { usePostStore } from 'shared/store/usePostStore';
 
 interface PropsType {
-	position: THREE.Vector3;
-	size: number;
-	color: string;
-	label: string;
+	data: PostData;
 	onClick: () => void;
 	isSelected: boolean;
 }
 
-export default function Post({
-	position,
-	size,
-	color,
-	label,
-	onClick,
-	isSelected,
-}: PropsType) {
+export default function Post({ data, onClick, isSelected }: PropsType) {
 	const { targetView, setTargetView } = useCameraStore();
 	const meshRef = useRef<THREE.Mesh>(null!);
 	const { view, setView } = useViewStore();
+	const { setData } = usePostStore();
 
 	const handleMeshClick = (e: ThreeEvent<MouseEvent>) => {
 		e.stopPropagation();
@@ -38,20 +31,21 @@ export default function Post({
 			return;
 		}
 
-		setView('WRITING');
+		setData(data);
+		setView('POST');
 	};
 
 	return (
 		<Star
-			position={position}
-			size={size}
-			color={color}
+			position={data.position}
+			size={data.size}
+			color={data.color}
 			onClick={handleMeshClick}
 			ref={meshRef}
 		>
 			{view === 'DETAIL' && isSelected && (
 				<Html>
-					<Label>{label}</Label>
+					<Label>{data.title}</Label>
 				</Html>
 			)}
 		</Star>

--- a/packages/client/src/entities/posts/ui/Posts.tsx
+++ b/packages/client/src/entities/posts/ui/Posts.tsx
@@ -10,10 +10,7 @@ export default function Posts() {
 			{dummyData.map((data, index) => (
 				<Post
 					key={index}
-					position={data.position}
-					size={data.size}
-					color={data.color}
-					label={data.label}
+					data={data}
 					onClick={() => setPost(index)}
 					isSelected={post === index}
 				/>
@@ -27,18 +24,30 @@ const dummyData = [
 		position: new THREE.Vector3(1000, 1000, 1800),
 		size: 100,
 		color: 'red',
-		label: '별글입니당',
+		title: '별글입니당',
+		content: '# 배가고프다',
+		images: [
+			'https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/ed205126-f8c5-4f84-98d9-fade19cd6c1d',
+		],
 	},
 	{
 		position: new THREE.Vector3(1300, 500, 1000),
 		size: 200,
 		color: 'blue',
-		label: '별글입니당',
+		title: '별글입니당',
+		content: '~stroke~',
+		images: [
+			'https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/ed205126-f8c5-4f84-98d9-fade19cd6c1d',
+		],
 	},
 	{
 		position: new THREE.Vector3(3000, 1000, 2500),
 		size: 150,
 		color: 'yellow',
-		label: '별글입니당',
+		title: '별글입니당',
+		content: "- I'm hungry",
+		images: [
+			'https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/ed205126-f8c5-4f84-98d9-fade19cd6c1d',
+		],
 	},
 ]; // TODO: 서버로부터 받아온 데이터로 변경 필요

--- a/packages/client/src/features/controls/Controls.tsx
+++ b/packages/client/src/features/controls/Controls.tsx
@@ -4,7 +4,7 @@ import * as THREE from 'three';
 import { useCameraStore } from 'shared/store/useCameraStore';
 import { Camera, useFrame } from '@react-three/fiber';
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
-import { useViewStore } from 'shared/store/useWritingStore';
+import { useViewStore } from 'shared/store/useViewStore';
 
 const setCameraPosition = (
 	camera: Camera,
@@ -29,7 +29,7 @@ export default function Controls() {
 		const LENGTH_LIMIT = 1000 * delta;
 
 		if (targetView) targetView.getWorldPosition(targetPosition);
-		if (view === 'WRITING') {
+		if (view === 'POST') {
 			targetPosition
 				.sub(state.camera.position)
 				.applyAxisAngle(new THREE.Vector3(0, 1, 0), -Math.PI / 6)
@@ -47,7 +47,7 @@ export default function Controls() {
 			if (direction.length() > LENGTH_LIMIT) direction.setLength(LENGTH_LIMIT);
 
 			setCurrentView(currentView.add(direction));
-			if (view !== 'WRITING')
+			if (view !== 'POST')
 				setCameraPosition(state.camera, currentView, cameraToCurrentView);
 
 			controlsRef.current.target = currentView;

--- a/packages/client/src/features/postModal/PostModal.tsx
+++ b/packages/client/src/features/postModal/PostModal.tsx
@@ -1,0 +1,75 @@
+import { useViewStore } from 'shared/store/useViewStore';
+import { Button, Modal, ModalPortal } from 'shared/ui';
+import { PostData } from 'shared/lib/types/post';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import styled from '@emotion/styled';
+
+interface PropsType {
+	data: PostData;
+}
+
+export default function PostModal({ data }: PropsType) {
+	const { setView } = useViewStore();
+	return (
+		<ModalPortal>
+			<PostModalLayout
+				title={data.title}
+				rightButton={rightButton}
+				onClickGoBack={() => {
+					setView('DETAIL');
+				}}
+			>
+				<ImageContainer>
+					<Image
+						src={
+							data.images[0]
+							// TODO: 여러 이미지 출력할 수 있는 Carousel 구현
+						}
+						alt="img"
+					/>
+				</ImageContainer>
+				<TextContainer>
+					<ReactMarkdown remarkPlugins={[remarkGfm]}>
+						{data.content}
+					</ReactMarkdown>
+				</TextContainer>
+			</PostModalLayout>
+		</ModalPortal>
+	);
+}
+
+const rightButton = (
+	<Button
+		size="m"
+		buttonType={'warning-border'}
+		onClick={() => {
+			console.log('삭제');
+		}} // TODO: 삭제 기능 구현
+	>
+		삭제
+	</Button>
+);
+
+const PostModalLayout = styled(Modal)`
+	transform: translate(-10%, -50%);
+`;
+
+const TextContainer = styled.div`
+	overflow-y: auto;
+	width: 807px;
+
+	${({ theme: { colors } }) => ({
+		color: colors.text.secondary,
+	})}
+`;
+
+const ImageContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-bottom: 26px;
+`;
+
+const Image = styled.img`
+	width: 649px;
+`;

--- a/packages/client/src/features/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/features/writingModal/ui/WritingModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button, Modal } from 'shared/ui';
 import TextArea from 'shared/ui/textArea/TextArea';
 import { ModalPortal } from 'shared/ui';
-import { useViewStore } from 'shared/store/useWritingStore';
+import { useViewStore } from 'shared/store/useViewStore';
 import styled from '@emotion/styled';
 import Images from './Images';
 import axios from 'axios';

--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -1,13 +1,17 @@
 import { WritingModal } from 'features/writingModal';
 import Screen from 'widgets/screen';
-import { useViewStore } from 'shared/store/useWritingStore';
+import { useViewStore } from 'shared/store/useViewStore';
+import { usePostStore } from 'shared/store/usePostStore';
+import PostModal from 'features/postModal/PostModal';
 
 export default function Home() {
 	const { view } = useViewStore();
+	const { data } = usePostStore();
 
 	return (
 		<>
 			{view === 'WRITING' && <WritingModal />}
+			{view === 'POST' && <PostModal data={data} />}
 			<Screen />
 		</>
 	);

--- a/packages/client/src/shared/lib/types/post.ts
+++ b/packages/client/src/shared/lib/types/post.ts
@@ -1,0 +1,8 @@
+export interface PostData {
+	title: string;
+	position: THREE.Vector3;
+	size: number;
+	color: string;
+	content: string;
+	images: string[];
+}

--- a/packages/client/src/shared/store/usePostStore.ts
+++ b/packages/client/src/shared/store/usePostStore.ts
@@ -1,0 +1,19 @@
+import { PostData } from './../lib/types/post';
+import { create } from 'zustand';
+import * as THREE from 'three';
+
+interface PostState {
+	data: PostData;
+	setData: (data: PostData) => void;
+}
+
+export const usePostStore = create<PostState>((set) => ({
+	data: {
+		title: '',
+		content: '',
+		position: new THREE.Vector3(0, 0, 0),
+		size: 1,
+		color: '#000000',
+	},
+	setData: (data: PostData) => set({ data }),
+}));

--- a/packages/client/src/shared/store/useViewStore.ts
+++ b/packages/client/src/shared/store/useViewStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-type view = 'MAIN' | 'DETAIL' | 'WRITING';
+type view = 'MAIN' | 'DETAIL' | 'WRITING' | 'POST';
 
 interface ViewState {
 	view: view;


### PR DESCRIPTION
### 📎 이슈번호
#42 

### 📃 변경사항
글 조회 모달 구현

### 🫨 고민한 부분
캔버스에 모달을 띄울 수는 없어 데이터를 어떻게 모달창에 전달할까 하다가 간단하게 전역 스토어로 넣어주기로 결정했습니다.

### 📌 중점적으로 볼 부분
usePostStore에 data로 글 조회 모달에 띄울 데이터를 관리합니다. 별을 클릭하여 글 조회 뷰로 넘어갈때 해당 별의 데이터를 store에 넣어주는 방식입니다.

Post의 props가 너무길어져서 별 관련 정보들은 data로 다 묶어줬습니다.

차후에 하단바에서 글 작성 버튼을 클릭해 글 쓰기 모달을 불러오는 과정을 구현할때는 useViewStore에서 view의 상태를 "WRITING"으로 변경해주면 글작성 모달이 나타납니다. 

### 🎇 동작 화면
https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/480d34fb-2e5b-43e1-8b25-c6e8ad777561

### 💫 기타사항

차후에 이미지 캐러셀이나 슬라이드, 삭제 기능 구현이 필요합니다.
