### PR TITLE
[FE] 회원가입 절차 구현

### DIFF
--- a/packages/client/src/pages/Landing/index.tsx
+++ b/packages/client/src/pages/Landing/index.tsx
@@ -3,21 +3,30 @@ import LoginModal from 'widgets/loginModal';
 import LogoAndStart from 'widgets/logoAndStart';
 import SignUpModal from 'widgets/signupModal/SignUpModal';
 import { useReducer, useState } from 'react';
+import NickNameSetModal from 'widgets/nickNameSetModal/NickNameSetModal';
+import { useToastStore } from 'shared/store/useToastStore';
+import { Toast } from 'shared/ui';
 
-function pageReducer(state: number, action: { type: 'NEXT' | 'PREV' }) {
+const pageReducer = (
+	state: number,
+	action: { type: 'NEXT' | 'PREV' | 'SET'; pageIndex?: number },
+) => {
 	switch (action.type) {
 		case 'NEXT':
 			return state + 1;
 		case 'PREV':
 			return state - 1;
+		case 'SET':
+			return action.pageIndex ?? state;
 		default:
 			return state;
 	}
-}
+};
 
 export default function Landing() {
 	const [page, dispatch] = useReducer(pageReducer, 0);
 	const [mouse, setMouse] = useState([0.5, 0.5]);
+	const { text } = useToastStore.getState();
 
 	return (
 		<div
@@ -28,9 +37,12 @@ export default function Landing() {
 				]);
 			}}
 		>
+			{text && <Toast>{text}</Toast>}
+
 			{page === 0 && <LogoAndStart changePage={dispatch} />}
 			{page === 1 && <LoginModal changePage={dispatch} />}
 			{page === 2 && <SignUpModal changePage={dispatch} />}
+			{page === 3 && <NickNameSetModal changePage={dispatch} />}
 			<LandingScreen mousePosition={mouse} />
 		</div>
 	);

--- a/packages/client/src/shared/apis/signUp.ts
+++ b/packages/client/src/shared/apis/signUp.ts
@@ -9,6 +9,15 @@ export const getIsAvailableUsername = async (username: string) => {
 	return data;
 };
 
+export const getIsAvailableNickName = async (nickname: string) => {
+	const { data } = await instance({
+		method: 'GET',
+		url: `/auth/is-available-nickname?nickname=${nickname}`,
+	});
+
+	return data;
+};
+
 interface PostSignUpTypes {
 	username: string;
 	password: string;

--- a/packages/client/src/shared/apis/signUp.ts
+++ b/packages/client/src/shared/apis/signUp.ts
@@ -1,5 +1,14 @@
 import instance from './AxiosInterceptor';
 
+export const getIsAvailableUsername = async (username: string) => {
+	const { data } = await instance({
+		method: 'GET',
+		url: `/auth/is-available-username?username=${username}`,
+	});
+
+	return data;
+};
+
 interface PostSignUpTypes {
 	username: string;
 	password: string;

--- a/packages/client/src/shared/store/useSignUpStore.ts
+++ b/packages/client/src/shared/store/useSignUpStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface SignUpState {
+	id: string;
+	pw: string;
+	setId: (id: string) => void;
+	setPw: (password: string) => void;
+}
+
+export const useSignUpStore = create<SignUpState>((set) => ({
+	id: '',
+	pw: '',
+	setId: (id) => set((state) => ({ ...state, id })),
+	setPw: (password) => set((state) => ({ ...state, password })),
+}));

--- a/packages/client/src/shared/store/useToastStore.ts
+++ b/packages/client/src/shared/store/useToastStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface ToastState {
+	text: string;
+	setText: (text: string) => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+	text: '',
+	setText: (text) => {
+		set((state) => ({ ...state, text }));
+
+		setTimeout(() => {
+			set((state) => ({ ...state, text: '' }));
+		}, 3000);
+	},
+}));

--- a/packages/client/src/widgets/nickNameSetModal/lib/constants.ts
+++ b/packages/client/src/widgets/nickNameSetModal/lib/constants.ts
@@ -1,0 +1,1 @@
+export const engOrNumRegex = /^[a-zA-Z0-9]*$/;

--- a/packages/client/src/widgets/nickNameSetModal/ui/NickNameInputContainer.tsx
+++ b/packages/client/src/widgets/nickNameSetModal/ui/NickNameInputContainer.tsx
@@ -1,0 +1,147 @@
+import styled from '@emotion/styled';
+import { Button, Input } from 'shared/ui';
+import { useState } from 'react';
+import { Caption } from 'shared/ui/styles';
+import { css } from '@emotion/react';
+import { useEffect } from 'react';
+import { getIsAvailableNickName } from 'shared/apis';
+import { engOrNumRegex } from '../lib/constants';
+
+interface PropsTypes {
+	setValidNickName: React.Dispatch<React.SetStateAction<string>>;
+}
+
+type NickNameStateTypes = 'DEFAULT' | 'VALID' | 'INVALID' | 'DUPLICATED';
+
+const MIN_ID_LENGTH = 2;
+const MAX_ID_LENGTH = 10;
+
+export default function NickNameInputContainer({
+	setValidNickName,
+}: PropsTypes) {
+	const [nickName, setNickName] = useState('');
+	const [nickNameState, setNickNameState] =
+		useState<NickNameStateTypes>('DEFAULT');
+
+	useEffect(() => {
+		if (nickNameState === 'VALID') setValidNickName(nickName);
+		else setValidNickName('');
+	}, [nickName]);
+
+	const handleNickNameInput = ({
+		target,
+	}: React.ChangeEvent<HTMLInputElement>) => {
+		if (!engOrNumRegex.test(target.value)) return;
+		if (target.value.length > MAX_ID_LENGTH) return;
+
+		setNickNameState('DEFAULT');
+		setNickName(target.value);
+	};
+
+	const handleIdDuplicateCheck = async () => {
+		if (nickName.length < MIN_ID_LENGTH || nickName.length > MAX_ID_LENGTH) {
+			setNickNameState('INVALID');
+			return;
+		}
+
+		try {
+			const response = await getIsAvailableNickName(nickName);
+
+			if (response) {
+				setNickNameState('VALID');
+				setValidNickName(nickName);
+				return;
+			}
+		} catch (error) {
+			setNickNameState('DUPLICATED');
+		}
+	};
+
+	const getMessage = () => {
+		if (nickNameState === 'VALID') return '사용 가능한 닉네임입니다.';
+		if (nickNameState === 'DUPLICATED') return '이미 사용중인 닉네임입니다.';
+		return `${MIN_ID_LENGTH} - ${MAX_ID_LENGTH}자의 영어/숫자 닉네임을 입력해주세요.`;
+	};
+
+	return (
+		<Layout>
+			<InputContainer>
+				<IdInput
+					id="nickName"
+					label="닉네임"
+					placeholder="닉네임을 입력해주세요."
+					isEssential
+					value={nickName}
+					onChange={handleNickNameInput}
+					autoComplete="off"
+					state={nickNameState}
+				/>
+				<DuplicateCheckButton
+					onClick={handleIdDuplicateCheck}
+					size="m"
+					buttonType="Button"
+					disabled={nickNameState === 'VALID'}
+				>
+					중복확인
+				</DuplicateCheckButton>
+			</InputContainer>
+
+			<Message state={nickNameState}>{getMessage()}</Message>
+		</Layout>
+	);
+}
+
+const Layout = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 452px;
+`;
+
+const InputContainer = styled.div`
+	display: flex;
+	align-items: flex-end;
+	width: 100%;
+	gap: 8px;
+`;
+
+const IdInput = styled(Input)<{ state: NickNameStateTypes }>`
+	${({ state, theme: { colors } }) => {
+		if (state === 'VALID' || state === 'DEFAULT') return;
+
+		return css`
+			border-color: ${colors.text.warning};
+
+			&:focus {
+				border-color: ${colors.text.warning};
+			}
+
+			&:hover {
+				border-color: ${colors.text.warning};
+			}
+		`;
+	}};
+`;
+
+const DuplicateCheckButton = styled(Button)`
+	white-space: nowrap;
+	padding: 10px 12px;
+`;
+
+const Message = styled.p<{ state: NickNameStateTypes }>`
+	margin: 4px 0 0 0;
+
+	color: ${({ state, theme: { colors } }) => {
+		switch (state) {
+			case 'DEFAULT':
+				return colors.text.secondary;
+			case 'VALID':
+				return colors.text.confirm;
+			case 'INVALID':
+				return colors.text.warning;
+			case 'DUPLICATED':
+				return colors.text.warning;
+		}
+	}};
+
+	${Caption}
+`;

--- a/packages/client/src/widgets/signupModal/SignUpModal.tsx
+++ b/packages/client/src/widgets/signupModal/SignUpModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import IdInputContainer from './ui/IdInputContainer';
 import PwInputContainer from './ui/PwInputContainer';
 import CheckPwInputContainer from './ui/CheckPwInputContainer';
+import { useSignUpStore } from 'shared/store/useSignUpStore';
 
 interface PropsType {
 	changePage: React.Dispatch<{ type: 'NEXT' | 'PREV' }>;
@@ -25,14 +26,17 @@ export default function SignUpModal({ changePage }: PropsType) {
 		setIsAllInputValid(false);
 	}, [validId, validPw, validCheckPw]);
 
-	// const handleGoBackButton = () => {
-	// 	// TODO: 로그인 모달로 이동하도록 하기
-	// };
+	const handleGoBackButton = () => changePage({ type: 'PREV' });
 
 	const handleSignUpButton = () => {
 		if (!isAllInputValid) return;
 
-		// TODO: 회원가입 요청 보낸 후 로그인 모달로 이동
+		useSignUpStore.setState({
+			id: validId,
+			pw: validPw,
+		});
+
+		changePage({ type: 'NEXT' });
 	};
 
 	const signUpButton = (
@@ -50,7 +54,7 @@ export default function SignUpModal({ changePage }: PropsType) {
 		<Modal
 			title="회원가입"
 			rightButton={signUpButton}
-			onClickGoBack={() => changePage({ type: 'PREV' })}
+			onClickGoBack={handleGoBackButton}
 		>
 			<InputBarsContainer>
 				<IdInputContainer setValidId={setValidId} />

--- a/packages/client/src/widgets/signupModal/ui/IdInputContainer.tsx
+++ b/packages/client/src/widgets/signupModal/ui/IdInputContainer.tsx
@@ -5,6 +5,7 @@ import { engOrNumRegex } from '../lib/constants';
 import { Caption } from 'shared/ui/styles';
 import { css } from '@emotion/react';
 import { useEffect } from 'react';
+import { getIsAvailableUsername } from 'shared/apis';
 
 interface PropsTypes {
 	setValidId: React.Dispatch<React.SetStateAction<string>>;
@@ -33,20 +34,21 @@ export default function IdInputContainer({ setValidId }: PropsTypes) {
 		setId(target.value);
 	};
 
-	const handleIdDuplicateCheck = () => {
+	const handleIdDuplicateCheck = async () => {
 		if (id.length < MIN_ID_LENGTH || id.length > MAX_ID_LENGTH) {
 			setIdState('INVALID');
 			return;
 		}
 
-		// TODO: 서버에 요청
+		const response = await getIsAvailableUsername(id);
 
-		// TODO: 사용 가능한 아이디일 경우
-		setIdState('VALID');
-		setValidId(id);
+		if (response) {
+			setIdState('VALID');
+			setValidId(id);
+			return;
+		}
 
-		// TODO: 중복된 아이디일 경우
-		// setIdState('DUPLICATED');
+		setIdState('DUPLICATED');
 	};
 
 	const getMessage = () => {

--- a/packages/client/src/widgets/signupModal/ui/IdInputContainer.tsx
+++ b/packages/client/src/widgets/signupModal/ui/IdInputContainer.tsx
@@ -30,7 +30,6 @@ export default function IdInputContainer({ setValidId }: PropsTypes) {
 		if (target.value.length > MAX_ID_LENGTH) return;
 
 		setIdState('DEFAULT');
-
 		setId(target.value);
 	};
 
@@ -40,15 +39,17 @@ export default function IdInputContainer({ setValidId }: PropsTypes) {
 			return;
 		}
 
-		const response = await getIsAvailableUsername(id);
+		try {
+			const response = await getIsAvailableUsername(id);
 
-		if (response) {
-			setIdState('VALID');
-			setValidId(id);
-			return;
+			if (response) {
+				setIdState('VALID');
+				setValidId(id);
+				return;
+			}
+		} catch (error) {
+			setIdState('DUPLICATED');
 		}
-
-		setIdState('DUPLICATED');
 	};
 
 	const getMessage = () => {


### PR DESCRIPTION
### 📎 이슈번호
#8 #9 #10 #11 #12 #13 #140 #15 

### 📃 변경사항
- pageReducer 변경
  - 기존에는 prev와 next로밖에 움직일 수 없어서 set을 추가했습니다.
  - 이렇게되니까 너무 복잡해지는 것 같은데 useNavigate를 사용하는 것도 고려해보면 좋을 것 같네요. 
  - 현재 방식에서는 next 혹은 prev로 갈 때가 아니라면 페이지인덱스를 지정해줘야 하는데, 숫자로는 어떤 페이지인지 직관적으로 와닿지 않는 것 같습니다. 혹시 제가 pageReducer 사용법을 잘못 알고있다면 말해주세용. . 🥹
  - @bananaba @MinboyKim 여기에 대해서 의견 남겨주시면 감사하겠습니다. 
- 회원가입 관련한 api 작업들 추가
  - 좀 이상한 부분이 보인다면 코멘트주세요
- 회원가입모달에서 닉네임모달로 넘어갈 때 잠시 정보를 저장할 전역 store 추가
-  Toast 상태를 관리하기 위한 전역 store 추가
  - text 부분이 비어있으면 뜨지 않고, 비어있지 않으면 띄우도록 했습니다. 
  - 토스트를 사용할 때는 <Toast>를 직접 불러올 필요 없이  useToastStore 상태를 변경하면 됩니다.
- 닉네임모달 관련한 로직들 추가

### 🫨 고민한 부분
- 회원가입모달에서 닉네임모달로 넘어갈 때 정보를 어떻게 저장할 것인가
  - 로컬 스토리지를 사용하거나 Url에 붙여서 보내는 경우는 보안상 문제가 생길 수 있어서 코드 내에 보관하는 방법이 좋다고 생각했습니다.
  - 닉네임 모달과 회원가입모달의 부모 컴포넌트가 없어서 전역 store를 사용하여 저장하고 있습니다. 
  - 굳이 전역 store를 쓸 필요까지는 없을 것 같긴 한데 어제는 마땅한 방법이 생각나지 않아서 일단은 이렇게 뒀습니다. 좋은 방법이 있다면 코멘트 부탁드려요.
- Toast 상태를 어떻게 관리할 것인가
  - 전역에 store를 만들어두고, text가 빈문자열이 아닐 경우에만  Landing 페이지에 띄워지도록 했습니다.
  - text의 내용이 바뀔 경우 3초 뒤 다시 빈문자열로 바뀝니다.
  - 일단은 이렇게 해두긴 했는데 더 좋은 방법이 있을 것 같네요.

### 📌 중점적으로 볼 부분
- Toast 관리하는 부분
- 회원가입 모달에서 닉네임 모달로 넘어갈 때 정보 보관하는 부분
- api 연동하는 부분

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/1a18eb47-7882-455f-82b5-5bbdecc87d21

### 💫 기타사항
어제 작성해놓은 코드들인데
좀 집중하기 어려운 상황이었어서 산만한 상태에서 얼레벌레 짠 느낌이 있네요...
더 좋은 방법이 생각나면 바꿀 것 같습니다.

특히 Toast 관리하는 부분, 회원가입 모달에서 닉네임 모달로 넘어갈 때 정보 보관하는 부분, api 연동하는 부분에서
미흡한 점이 보이신다면 적극 피드백 부탁드립니다...


