### PR TITLE
[FE] 하단바, 상단바 UI 구현

### DIFF
--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -3,6 +3,8 @@ import Screen from 'widgets/screen';
 import { useViewStore } from 'shared/store/useViewStore';
 import { usePostStore } from 'shared/store/usePostStore';
 import PostModal from 'features/postModal/PostModal';
+import UnderBar from 'shared/ui/underBar/UnderBar';
+import UpperBar from './ui/UpperBar';
 
 export default function Home() {
 	const { view } = useViewStore();
@@ -12,6 +14,10 @@ export default function Home() {
 		<>
 			{view === 'WRITING' && <WritingModal />}
 			{view === 'POST' && <PostModal data={data} />}
+
+			<UpperBar />
+			<UnderBar />
+
 			<Screen />
 		</>
 	);

--- a/packages/client/src/pages/Home/ui/UpperBar.tsx
+++ b/packages/client/src/pages/Home/ui/UpperBar.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import { IconButton, Search } from 'shared/ui';
+import goBackIcon from '@icons/icon-back-32-white.svg';
+import { MAX_WIDTH1, MAX_WIDTH2 } from '@constants';
+import { useState } from 'react';
+
+export default function UpperBar() {
+	const [temp, setTemp] = useState('');
+
+	return (
+		<Layout>
+			<IconButton onClick={() => {}}>
+				<img src={goBackIcon} alt="뒤로가기" />
+			</IconButton>
+
+			<SearchBar
+				onClick={() => {}}
+				inputState={temp}
+				setInputState={setTemp}
+				placeholder="닉네임을 입력하세요"
+			/>
+		</Layout>
+	);
+}
+
+const Layout = styled.div`
+	position: absolute;
+	left: 50%;
+	top: 30px;
+	z-index: 50;
+	transform: translateX(-50%);
+
+	display: flex;
+	justify-content: space-between;
+	width: 1180px;
+
+	@media (max-width: ${MAX_WIDTH1}px) {
+		width: calc(100% - 30px);
+	}
+
+	@media (max-width: ${MAX_WIDTH2}px) {
+		width: 1000px;
+	}
+`;
+
+const SearchBar = styled(Search)`
+	width: 320px;
+`;

--- a/packages/client/src/pages/Home/ui/index.ts
+++ b/packages/client/src/pages/Home/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './UpperBar';

--- a/packages/client/src/shared/lib/constants/index.ts
+++ b/packages/client/src/shared/lib/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './camera';
 export * from './space';
 export * from './api';
+export * from './width';

--- a/packages/client/src/shared/lib/constants/width.ts
+++ b/packages/client/src/shared/lib/constants/width.ts
@@ -1,0 +1,2 @@
+export const MAX_WIDTH1 = 1210;
+export const MAX_WIDTH2 = 1030;

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -15,6 +15,7 @@ export default function Search({
 	inputState,
 	setInputState,
 	placeholder = '',
+	...args
 }: PropsTypes) {
 	const onChangeSearchInput = ({
 		target,
@@ -23,7 +24,7 @@ export default function Search({
 	};
 
 	return (
-		<Layout>
+		<Layout {...args}>
 			<img src={searchIcon} alt="돋보기 아이콘" />
 
 			<SearchInput

--- a/packages/client/src/shared/ui/toast/Toast.tsx
+++ b/packages/client/src/shared/ui/toast/Toast.tsx
@@ -31,7 +31,7 @@ const fadeOutAnimation = keyframes`
 const Layout = styled.div`
 	display: flex;
 	position: absolute;
-	top: 53px;
+	top: 30px;
 	left: 50%;
 	transform: translate(-50%, 0%);
 	z-index: 1000;

--- a/packages/client/src/shared/ui/underBar/UnderBar.tsx
+++ b/packages/client/src/shared/ui/underBar/UnderBar.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled';
+import { Button } from 'shared/ui';
+import { css } from '@emotion/react';
+import { Title01 } from '../styles';
+import PlanetEditIcon from '@icons/icon-planetedit-24-white.svg';
+import AddIcon from '@icons/icon-add-24-white.svg';
+import WriteIcon from '@icons/icon-writte-24-white.svg';
+
+export default function UnderBar() {
+	const tempName = '도라에몽도라에몽도라';
+
+	return (
+		<Layout>
+			<Name>{tempName}님의 은하</Name>
+
+			<ButtonsContainer>
+				<LogoutButton size="l" buttonType="Button">
+					로그아웃
+				</LogoutButton>
+
+				<Line />
+
+				<SpaceEditButton size="l" buttonType="Button">
+					<img src={PlanetEditIcon} alt="우주 수정하기" />
+					우주 수정하기
+				</SpaceEditButton>
+				<SkinCreateButton size="l" buttonType="Button">
+					<img src={AddIcon} alt="별 스킨 만들기" />별 스킨 만들기
+				</SkinCreateButton>
+				<WritingButton size="l" buttonType="CTA-icon">
+					<img src={WriteIcon} alt="글쓰기" />
+					글쓰기
+				</WritingButton>
+			</ButtonsContainer>
+		</Layout>
+	);
+}
+
+const Layout = styled.div`
+	position: absolute;
+	z-index: 50;
+	left: 50%;
+	bottom: 50px;
+	transform: translateX(-50%);
+
+	display: flex;
+	padding: 24px;
+	width: 1180px; // TODO: 수정 필요
+	justify-content: space-between;
+	align-items: center;
+	border-radius: 12px;
+
+	background-color: ${({ theme }) => theme.colors.background.bdp01_80};
+	border: 1px solid ${({ theme }) => theme.colors.stroke.default};
+`;
+
+const Name = styled.p`
+	color: ${({ theme }) => theme.colors.text.primary};
+	${Title01}
+`;
+
+const ButtonsContainer = styled.div`
+	display: flex;
+`;
+
+const ButtonBasicStyle = css`
+	width: 155px;
+	height: 70px;
+`;
+
+const LogoutButton = styled(Button)`
+	height: 70px;
+	margin: 0 24px 0 0;
+`;
+
+const SpaceEditButton = styled(Button)`
+	${ButtonBasicStyle}
+	margin: 0 8px 0 0;
+`;
+
+const SkinCreateButton = styled(Button)`
+	${ButtonBasicStyle}
+	margin: 0 16px 0 0;
+`;
+
+const WritingButton = styled(Button)`
+	${ButtonBasicStyle}
+`;
+
+const Line = styled.div`
+	margin: 0 24px 0 0;
+	border-left: 1px solid ${({ theme }) => theme.colors.stroke.sc};
+`;

--- a/packages/client/src/shared/ui/underBar/UnderBar.tsx
+++ b/packages/client/src/shared/ui/underBar/UnderBar.tsx
@@ -40,7 +40,7 @@ export default function UnderBar() {
 const Layout = styled.div`
 	position: absolute;
 	left: 50%;
-	bottom: 50px;
+	bottom: 30px;
 	z-index: 50;
 	transform: translateX(-50%);
 

--- a/packages/client/src/shared/ui/underBar/UnderBar.tsx
+++ b/packages/client/src/shared/ui/underBar/UnderBar.tsx
@@ -5,6 +5,7 @@ import { Title01 } from '../styles';
 import PlanetEditIcon from '@icons/icon-planetedit-24-white.svg';
 import AddIcon from '@icons/icon-add-24-white.svg';
 import WriteIcon from '@icons/icon-writte-24-white.svg';
+import { MAX_WIDTH1, MAX_WIDTH2 } from 'shared/lib/constants';
 
 export default function UnderBar() {
 	const tempName = '도라에몽도라에몽도라';
@@ -38,20 +39,28 @@ export default function UnderBar() {
 
 const Layout = styled.div`
 	position: absolute;
-	z-index: 50;
 	left: 50%;
 	bottom: 50px;
+	z-index: 50;
 	transform: translateX(-50%);
 
 	display: flex;
 	padding: 24px;
-	width: 1180px; // TODO: 수정 필요
 	justify-content: space-between;
 	align-items: center;
 	border-radius: 12px;
+	width: 1180px;
 
 	background-color: ${({ theme }) => theme.colors.background.bdp01_80};
 	border: 1px solid ${({ theme }) => theme.colors.stroke.default};
+
+	@media (max-width: ${MAX_WIDTH1}px) {
+		width: calc(100% - 30px);
+	}
+
+	@media (max-width: ${MAX_WIDTH2}px) {
+		width: 1000px;
+	}
 `;
 
 const Name = styled.p`


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 하단바 컴포넌트 생성
  - 피그마 디자인보다 전체적으로 더 작게 수정했습니다.
  - 유저명은 임시로 넣어두었습니다.
- 상단바 추가
  - Search 컴포넌트와 뒤로가기 버튼을 추가했습니다. 
- 화면의 상하 padding을 50px정도에서 30px로 수정했습니다.
  - Toast의 위치도 같이 수정했습니다.

### 🫨 고민한 부분
아는 디자이너분께 화면이 가로로 길어질 때 하단바도 같이 길어지는게 좋냐고 물어봤는데
사용자 관점에서 좌-우 시각범위가 길어지면 쉽게 피로감을 느낀다고 하네요
그래서 연두색 부분의 최대 width값은 1180px로 고정해두고,
화면이 더 작아졌을 때만 조금 더 줄어들도록 구현했습니다. 

<img width="623" alt="무제 20" src="https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/d7e92b39-3399-4447-a7f5-e5faec66f13a">

원래는 연두색 부분 레이아웃을 따로 만들어두고, 
그 안에 하단바와 상단바를 추가하여
하단바 width를 100%로 주고 상단바는 justify-content: space-between으로 주려고 했습니다.

하지만 그렇게 하니 연두색 부분이 화면 전체를 덮어버려서 우주부분 컨트롤이 안되더라구영. .......

그래서 상단바와 하단바를 따로 두었습니다. 
뒤로가기 버튼과 검색바를 따로 두지 않고 상단바 안에 넣어버려서
상단바 부분 (뒤로가기 버튼과 검색바 사이 공간)은 마우스 컨트롤이 안되긴합니다. 

### 📌 중점적으로 볼 부분
- style 부분
- media query 부분

### 🎇 동작 화면


Uploading 화면 기록 2023-11-26 오후 7.25.45.mov…

한 15분째 시도하고잇는데 영상이 참 안올라가네요 
그냥 사진으로 대체하겟습니다 ^^

- 창이 클 때
<img width="1512" alt="무제 2020" src="https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/0fcc042d-8537-4745-99f9-973b45b3d0e9">
- 창이 작을 때
<img width="1224" alt="무제 2021" src="https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/6df887b1-a7b2-4b3b-a7ca-cb092b57c2d7">



### 💫 기타사항
아직도 하단바가 좀 큰 느낌이 있긴한데..
다들어떻게생각하시나요
