### PR TITLE
[FE] 라우팅 방식 설정

### DIFF
--- a/packages/client/src/app/Router.tsx
+++ b/packages/client/src/app/Router.tsx
@@ -1,8 +1,19 @@
-import { createBrowserRouter } from 'react-router-dom';
+import {
+	Route,
+	createBrowserRouter,
+	createRoutesFromElements,
+} from 'react-router-dom';
 import Home from '../pages/Home';
 import Landing from '../pages/Landing';
+import { WritingModal } from 'features/writingModal';
 
-export const router = createBrowserRouter([
-	{ path: '/', element: <Landing /> },
-	{ path: '/home', element: <Home /> },
-]);
+export const router = createBrowserRouter(
+	createRoutesFromElements(
+		<>
+			<Route index path="/" element={<Landing />} />
+			<Route path="/home" element={<Home />}>
+				<Route path="writing" element={<WritingModal />} />
+			</Route>
+		</>,
+	),
+);

--- a/packages/client/src/features/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/features/writingModal/ui/WritingModal.tsx
@@ -2,19 +2,18 @@ import { useState } from 'react';
 import { Button, Modal } from 'shared/ui';
 import TextArea from 'shared/ui/textArea/TextArea';
 import { ModalPortal } from 'shared/ui';
-import { useViewStore } from 'shared/store/useViewStore';
-import styled from '@emotion/styled';
 import Images from './Images';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export default function WritingModal() {
 	const [text, setText] = useState('');
 	const [files, setFiles] = useState<FileList | null>(null);
-	const { setView } = useViewStore();
+	const navigate = useNavigate();
 
 	return (
 		<ModalPortal>
-			<WritingModalLayout
+			<Modal
 				title="글쓰기"
 				rightButton={
 					<Button
@@ -26,17 +25,13 @@ export default function WritingModal() {
 					</Button>
 				}
 				leftButton={<Images onModify={setFiles} />}
-				onClickGoBack={() => setView('DETAIL')}
+				onClickGoBack={() => navigate('/home')}
 			>
 				<TextArea onChange={(text) => setText(text)} />
-			</WritingModalLayout>
+			</Modal>
 		</ModalPortal>
 	);
 }
-
-const WritingModalLayout = styled(Modal)`
-	transform: translate(-10%, -50%);
-`;
 
 const sendToServer = async (text: string, files: FileList | null) => {
 	try {

--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -1,8 +1,8 @@
-import { WritingModal } from 'features/writingModal';
 import Screen from 'widgets/screen';
 import { useViewStore } from 'shared/store/useViewStore';
 import { usePostStore } from 'shared/store/usePostStore';
 import PostModal from 'features/postModal/PostModal';
+import { Outlet } from 'react-router-dom';
 
 export default function Home() {
 	const { view } = useViewStore();
@@ -10,7 +10,7 @@ export default function Home() {
 
 	return (
 		<>
-			{view === 'WRITING' && <WritingModal />}
+			<Outlet />
 			{view === 'POST' && <PostModal data={data} />}
 			<Screen />
 		</>


### PR DESCRIPTION
### 📎 이슈번호
#86 

### 📃 변경사항
모달을 띄울 때 url도 변경해주는 것이 좋을 것 같아 방식을 조금 바꿔봤습니다.
Canvas를 그리는 Home 컴포넌트를 부모 라우트로 설정하고 하위 라우트에 모달들을 위치시킨 뒤 Home 컴포넌트에 하위 라우트인 모달들이 위치할 곳에 Outlet 컴포넌트를 두는 것으로 구현했습니다.

### 🫨 고민한 부분
지금까지 진행한 부분들에 수정이 필요해보입니다.

### 📌 중점적으로 볼 부분
매번 view state를 변경해야하는 이전 방식보다 좀 더 좋아진 방식이라는 생각이 듭니다.

### 🎇 동작 화면
<img width="1582" alt="스크린샷 2023-11-27 오후 5 11 27" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/f7fce0ec-78eb-4da4-9f48-550254e5e9b7">

### 💫 기타사항
