### PR TITLE
[BE] Auth Controller의 Swagger 부분 리팩토링

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -31,6 +31,11 @@ import {
 import { JwtEnum } from './enums/jwt.enum';
 import { CookieAuthGuard } from './cookie-auth.guard';
 import { UserEnum } from './enums/user.enum';
+import { SignUpSwaggerDecorator } from './decorators/swagger/sign-up-swagger.decorator';
+import { SignInSwaggerDecorator } from './decorators/swagger/sign-in-swagger.decorator';
+import { SignOutSwaggerDecorator } from './decorators/swagger/sign-out-swagger.decorator';
+import { IsAvailableUsernameSwaggerDecorator } from './decorators/swagger/is-available-username-swagger.decorator';
+import { IsAvailableNicknameSwaggerDecorator } from './decorators/swagger/is-available-nickname-swagger.decorator';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -39,24 +44,14 @@ export class AuthController {
 
 	@Post('signup')
 	@UsePipes(ValidationPipe)
-	@ApiOperation({ summary: '회원가입', description: '회원가입을 진행합니다.' })
-	@ApiCreatedResponse({ status: 201, description: '회원가입 성공' })
-	@ApiBadRequestResponse({
-		status: 400,
-		description: '잘못된 요청으로 회원가입 실패',
-	})
+	@SignUpSwaggerDecorator()
 	signUp(@Body() signUpUserDto: SignUpUserDto): Promise<Partial<User>> {
 		return this.authService.signUp(signUpUserDto);
 	}
 
 	@Post('signin')
 	@HttpCode(200)
-	@ApiOperation({ summary: '로그인', description: '로그인을 진행합니다.' })
-	@ApiOkResponse({ status: 200, description: '로그인 성공' })
-	@ApiUnauthorizedResponse({
-		status: 401,
-		description: '잘못된 요청으로 로그인 실패',
-	})
+	@SignInSwaggerDecorator()
 	async signIn(
 		@Body() signInUserDto: SignInUserDto,
 		@Res({ passthrough: true }) res: Response,
@@ -76,8 +71,7 @@ export class AuthController {
 
 	@Get('signout')
 	@UseGuards(CookieAuthGuard)
-	@ApiOperation({ summary: '로그아웃', description: '로그아웃을 진행합니다.' })
-	@ApiOkResponse({ status: 200, description: '로그아웃 성공' })
+	@SignOutSwaggerDecorator()
 	async signOut(@Res({ passthrough: true }) res: Response, @Req() req) {
 		await this.authService.signOut(req.user);
 		res.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, {
@@ -92,37 +86,13 @@ export class AuthController {
 	}
 
 	@Get('is-available-username')
-	@ApiOperation({
-		summary: 'username 중복 확인',
-		description: 'username 중복을 확인합니다.',
-	})
-	@ApiOkResponse({ status: 200, description: 'username 중복 확인 성공' })
-	@ApiBadRequestResponse({
-		status: 400,
-		description: '쿼리 스트링에 username이 없음',
-	})
-	@ApiConflictResponse({
-		status: 409,
-		description: 'username 중복',
-	})
+	@IsAvailableUsernameSwaggerDecorator()
 	isAvailableUsername(@Query('username') username: string) {
 		return this.authService.isAvailableUsername(username);
 	}
 
 	@Get('is-available-nickname')
-	@ApiOperation({
-		summary: 'nickname 중복 확인',
-		description: 'nickname 중복을 확인합니다.',
-	})
-	@ApiOkResponse({ status: 200, description: 'nickname 중복 확인 성공' })
-	@ApiBadRequestResponse({
-		status: 400,
-		description: '쿼리 스트링에 nickname이 없음',
-	})
-	@ApiConflictResponse({
-		status: 409,
-		description: 'nickname 중복',
-	})
+	@IsAvailableNicknameSwaggerDecorator()
 	isAvailableNickname(@Query('nickname') nickname: string) {
 		return this.authService.isAvailableNickname(nickname);
 	}

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -19,15 +19,7 @@ import { SignUpUserDto } from './dto/signup-user.dto';
 import { User } from './entities/user.entity';
 import { SignInUserDto } from './dto/signin-user.dto';
 import { Response } from 'express';
-import {
-	ApiBadRequestResponse,
-	ApiConflictResponse,
-	ApiCreatedResponse,
-	ApiOkResponse,
-	ApiOperation,
-	ApiTags,
-	ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { JwtEnum } from './enums/jwt.enum';
 import { CookieAuthGuard } from './cookie-auth.guard';
 import { UserEnum } from './enums/user.enum';
@@ -36,6 +28,9 @@ import { SignInSwaggerDecorator } from './decorators/swagger/sign-in-swagger.dec
 import { SignOutSwaggerDecorator } from './decorators/swagger/sign-out-swagger.decorator';
 import { IsAvailableUsernameSwaggerDecorator } from './decorators/swagger/is-available-username-swagger.decorator';
 import { IsAvailableNicknameSwaggerDecorator } from './decorators/swagger/is-available-nickname-swagger.decorator';
+import { SignInWithOAuthSwaggerDecorator } from './decorators/swagger/sign-in-with-oauth-swagger.decorator';
+import { SignUpWithOAuthSwaggerDecorator } from './decorators/swagger/sign-up-with-oauth-swagger.decorator';
+import { OAuthCallbackSwaggerDecorator } from './decorators/swagger/oauth-callback-swagger.decorator';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -98,6 +93,7 @@ export class AuthController {
 	}
 
 	@Get(':service/signin')
+	@SignInWithOAuthSwaggerDecorator()
 	signInWithOAuth(
 		@Param('service') service: string,
 		@Res({ passthrough: true }) res: Response,
@@ -120,6 +116,7 @@ export class AuthController {
 	}
 
 	@Get(':service/callback')
+	@OAuthCallbackSwaggerDecorator()
 	async oauthCallback(
 		@Param('service') service: string,
 		@Query('code') authorizedCode: string,
@@ -150,6 +147,7 @@ export class AuthController {
 	}
 
 	@Post(':service/signup')
+	@SignUpWithOAuthSwaggerDecorator()
 	async signUpWithOAuth(
 		@Param('service') service: string,
 		@Body('nickname') nickname: string,

--- a/packages/server/src/auth/decorators/swagger/is-available-nickname-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/is-available-nickname-swagger.decorator.ts
@@ -1,0 +1,36 @@
+import {
+	ApiBadRequestResponse,
+	ApiConflictResponse,
+	ApiOkResponse,
+	ApiOperation,
+} from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+
+const apiOperation = {
+	summary: 'nickname 중복 확인',
+	description: 'nickname 중복을 확인합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description: 'nickname 중복 아님(회원가입 가능)',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '쿼리 스트링에 nickname이 없음',
+};
+
+const apiConflictResponse = {
+	status: 409,
+	description: 'nickname 중복(회원가입 불가능)',
+};
+
+export const IsAvailableNicknameSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiConflictResponse(apiConflictResponse),
+	);
+};

--- a/packages/server/src/auth/decorators/swagger/is-available-username-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/is-available-username-swagger.decorator.ts
@@ -1,0 +1,36 @@
+import {
+	ApiBadRequestResponse,
+	ApiConflictResponse,
+	ApiOkResponse,
+	ApiOperation,
+} from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+
+const apiOperation = {
+	summary: 'username 중복 확인',
+	description: 'username 중복을 확인합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description: 'username 중복 아님(회원가입 가능)',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '쿼리 스트링에 username이 없음',
+};
+
+const apiConflictResponse = {
+	status: 409,
+	description: 'username 중복(회원가입 불가능)',
+};
+
+export const IsAvailableUsernameSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiConflictResponse(apiConflictResponse),
+	);
+};

--- a/packages/server/src/auth/decorators/swagger/oauth-callback-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/oauth-callback-swagger.decorator.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: 'OAuth 로그인 콜백',
+	description:
+		'OAuth 로그인 콜백을 진행합니다.\n' + '서버 내부에서만 동작하는 API입니다.',
+};
+
+export const OAuthCallbackSwaggerDecorator = () => {
+	return applyDecorators(ApiOperation(apiOperation));
+};

--- a/packages/server/src/auth/decorators/swagger/sign-in-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/sign-in-swagger.decorator.ts
@@ -1,0 +1,29 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiOkResponse,
+	ApiOperation,
+	ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '로그인',
+	description: 'username, password를 받아 로그인을 진행합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description: '로그인이 성공해 쿠키에 토큰이 저장됨',
+};
+
+const apiUnauthorizedResponse = {
+	status: 401,
+	description: '잘못된 유저 정보로 로그인 실패',
+};
+
+export const SignInSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiUnauthorizedResponse(apiUnauthorizedResponse),
+	);
+};

--- a/packages/server/src/auth/decorators/swagger/sign-in-with-oauth-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/sign-in-with-oauth-swagger.decorator.ts
@@ -1,0 +1,15 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: 'OAuth 로그인',
+	description:
+		'OAuth 로그인을 진행합니다.\n' +
+		'OAuth 로그인은 Google, Naver, GitHub을 지원합니다.\n' +
+		'/api/auth/{서비스명}/signin으로 요청하면 해당 서비스의 OAuth 로그인 페이지로 리다이렉트됩니다.\n' +
+		'서비스 명에는 google, naver, github 중 하나를 입력해야 합니다.',
+};
+
+export const SignInWithOAuthSwaggerDecorator = () => {
+	return applyDecorators(ApiOperation(apiOperation));
+};

--- a/packages/server/src/auth/decorators/swagger/sign-out-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/sign-out-swagger.decorator.ts
@@ -1,0 +1,29 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiOperation,
+	ApiBadRequestResponse,
+	ApiCreatedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '로그아웃',
+	description: '쿠키의 토큰을 읽어 해당 회원의 로그아웃을 진행합니다.',
+};
+
+const apiCreatedResponse = {
+	status: 200,
+	description: '로그아웃 성공으로 쿠키의 토큰과 Redis의 토큰 정보가 삭제됨',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '쿠키에 토큰이 없음(로그인 하지 않은 회원)',
+};
+
+export const SignOutSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiCreatedResponse(apiCreatedResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+	);
+};

--- a/packages/server/src/auth/decorators/swagger/sign-up-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/sign-up-swagger.decorator.ts
@@ -1,0 +1,36 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiOperation,
+	ApiBadRequestResponse,
+	ApiConflictResponse,
+	ApiCreatedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '회원가입',
+	description: 'username, password, nickname을 받아 회원 가입을 진행합니다.',
+};
+
+const apiCreatedResponse = {
+	status: 201,
+	description: '회원가입 완료로 회원 정보가 데이터베이스에 저장됨',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '회원 가입에 필요한 정보들이 형식에 맞지 않음',
+};
+
+const apiConflictResponse = {
+	status: 409,
+	description: '이미 존재하는 username 또는 nickname이 사용됨',
+};
+
+export const SignUpSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiCreatedResponse(apiCreatedResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiConflictResponse(apiConflictResponse),
+	);
+};

--- a/packages/server/src/auth/decorators/swagger/sign-up-with-oauth-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/sign-up-with-oauth-swagger.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiCreatedResponse,
+	ApiOperation,
+	ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: 'OAuth를 통한 회원가입',
+	description:
+		'OAuth를 통한 첫 로그인인 경우 회원가입을 진행합니다.\n' +
+		'signin을 통해 발급 받은 쿠키의 {서비스명}Username을 이용해 회원가입을 진행합니다.\n' +
+		'Post 요청 body에 nickname 정보를 담아 요청해야 합니다.',
+};
+
+const apiCreatedResponse = {
+	status: 201,
+	description: 'OAuth를 통한 회원가입 성공',
+};
+
+const apiUnauthorizedResponse = {
+	status: 401,
+	description:
+		'쿠키에 Username이 없거나 Redis에 저장된 정보가 없음(OAuth signin을 하지 않았음)',
+};
+
+export const SignUpWithOAuthSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiCreatedResponse(apiCreatedResponse),
+		ApiUnauthorizedResponse(apiUnauthorizedResponse),
+	);
+};


### PR DESCRIPTION
### 📎 이슈번호

- [15-01] Api들에 Swagger 설정을 적용한다. #96 

### 📃 변경사항

Auth Controller에서 Swagger 관련 데코레이터부분 새로운 데코레이터로 분리
OAuth 관련 Api에 Swagger 데코레이터 추가

### 🫨 고민한 부분

Swagger 관련 데코레이터들이 너무 난잡하고 가독성을 떨어뜨려서 새로운 데코레이터로 통합하여 분리하고자 함

### 📌 중점적으로 볼 부분

수정 전과 수정 후 Swagger 데코레이터 부분이 확실히 깔끔해졌습니다.

### 🎇 동작 화면

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/971a7ac7-aa17-4ca7-a3af-49e9f6c0f876)


### 💫 기타사항
