### PR TITLE
[BE] 닉네임 검색 API 구현

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -182,4 +182,9 @@ export class AuthController {
 
 		return savedUser;
 	}
+
+	@Get('search')
+	searchUser(@Query('nickname') nickname: string) {
+		return this.authService.searchUser(nickname);
+	}
 }

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -188,12 +188,9 @@ export class AuthService {
 		const users: User[] = await this.userRepository
 			.createQueryBuilder('user')
 			.select(['user.id', 'user.nickname'])
-			.where(
-				`MATCH (user.nickname) AGAINST (:nickname IN NATURAL LANGUAGE MODE)`,
-				{
-					nickname,
-				},
-			)
+			.where(`MATCH (user.nickname) AGAINST (:nickname IN BOOLEAN MODE)`, {
+				nickname: nickname + '*',
+			})
 			.getMany();
 		return users;
 	}

--- a/packages/server/src/auth/entities/user.entity.ts
+++ b/packages/server/src/auth/entities/user.entity.ts
@@ -3,11 +3,13 @@ import {
 	Column,
 	CreateDateColumn,
 	Entity,
+	Index,
 	OneToMany,
 	PrimaryGeneratedColumn,
 } from 'typeorm';
 
 @Entity()
+@Index('IDX_FULLTEXT_NICKNAME', ['nickname'], { fulltext: true })
 export class User {
 	@PrimaryGeneratedColumn()
 	id: number;


### PR DESCRIPTION
### 📎 이슈번호

- [16-01] 서버는 닉네임 데이터를 받아 유저를 조회한다. #187 

### 📃 변경사항

데이터베이스 nickname 컬럼 FULLTEXT 인덱싱
nickname 값을 받아 해당 nickname 값으로 시작하는 닉네임을 가진 유저들을 검색하는 Service 로직 구현
검색 API 구현
User Entity에 nickname컬럼 FULLTEXT 인덱싱을 위한 `@Index` 데코레이터 추가

### 🫨 고민한 부분

MySQL의 전문검색과 AGINST 연산자에 쓰이는 모드들
서버가 실행되고 typeorm이 자동으로 `@Entity`가 붙은 엔티티들의 테이블을 갱신할때 사라지는 인덱스를 서버 실행시마다 생성해주는 방법

### 📌 중점적으로 볼 부분

[개발 기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%A4%80%EC%84%AD%5D-1129(%EC%88%98)-%EA%B0%9C%EB%B0%9C-%EA%B8%B0%EB%A1%9D-%E2%80%90-NestJS---TypeORM%EC%9C%BC%EB%A1%9C-MySQL-%EC%A0%84%EB%AC%B8%EA%B2%80%EC%83%89-%EA%B5%AC%ED%98%84) 봐주시며 감사하겠습니다 ㅎㅎ
개발 기록 안에 학습 기록 링크도 있는데 나름 괜찮은 내용인 것 같아서 그것도 봐주시면 감사하겠습니다!

### 🎇 동작 화면

테스트용으로 데이터베이스에 저장한 유저 데이터들

![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/4b0c932e-d1e6-40e9-b799-72db25b2b53e)

Postman 테스트
```
localhost:3000/auth/search?nickname=테스트
```

결과가 잘 출력된 모습
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/5538d6d0-5daa-497b-8f85-e19ddc4b2031)

### 💫 기타사항
