### PR TITLE
[BE] SignIn 에러 상태 코드 수정

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import {
 	BadRequestException,
 	ConflictException,
 	Injectable,
+	NotFoundException,
 	UnauthorizedException,
 } from '@nestjs/common';
 import { SignUpUserDto } from './dto/signup-user.dto';
@@ -57,8 +58,13 @@ export class AuthService {
 
 		const user = await this.userRepository.findOneBy({ username });
 
-		if (!(user && (await bcrypt.compare(password, user.password)))) {
-			throw new UnauthorizedException(UserEnum.FAIL_SIGNIN_MESSAGE);
+		if (!user) {
+			throw new NotFoundException(UserEnum.NOT_EXIST_USERNAME_MESSAGE);
+		}
+
+		const isCorrectPassword = await bcrypt.compare(password, user.password);
+		if (!isCorrectPassword) {
+			throw new UnauthorizedException(UserEnum.UNCORRECT_PASSWORD_MESSAGE);
 		}
 
 		const [accessToken, refreshToken] = await Promise.all([

--- a/packages/server/src/auth/dto/signin-user.dto.ts
+++ b/packages/server/src/auth/dto/signin-user.dto.ts
@@ -12,9 +12,6 @@ export class SignInUserDto {
 		example: 'test user',
 		required: true,
 	})
-	@IsNotEmpty({ message: UserEnum.USERNAME_NOTEMPTY_MESSAGE as string })
-	@IsString({ message: UserEnum.USERNAME_ISSTRING_MESSAGE as string })
-	@IsUsername()
 	username: string;
 
 	@ApiProperty({
@@ -22,8 +19,5 @@ export class SignInUserDto {
 		example: 'test password',
 		required: true,
 	})
-	@IsNotEmpty({ message: UserEnum.PASSWORD_NOTEMPTY_MESSAGE as string })
-	@IsString({ message: UserEnum.PASSWORD_ISSTRING_MESSAGE as string })
-	@IsPassword()
 	password: string;
 }

--- a/packages/server/src/auth/enums/user.enum.ts
+++ b/packages/server/src/auth/enums/user.enum.ts
@@ -18,7 +18,8 @@ export enum UserEnum {
 	VIOLATE_PASSWORD_MESSAGE = `비밀번호는 ${MIN_PASSWORD_LENGTH}~${MAX_PASSWORD_LENGTH}자여야 합니다.`,
 	VIOLATE_NICKNAME_MESSAGE = `닉네임은 영문자, 숫자, 한글로 이루어진 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}자여야 합니다.`,
 
-	FAIL_SIGNIN_MESSAGE = '아이디에 해당하는 회원이 존재하지 않거나 비밀번호가 일치하지 않습니다.',
+	NOT_EXIST_USERNAME_MESSAGE = '아이디에 해당하는 회원이 존재하지 않습니다.',
+	UNCORRECT_PASSWORD_MESSAGE = '비밀번호가 일치하지 않습니다.',
 
 	SUCCESS_SIGNOUT_MESSAGE = '로그아웃에 성공했습니다.',
 }


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 로그인시 아이디가 없으면 404 에러 상태코드 반환
- 비밀번호가 틀리면 401에러 상태코드 반환

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

존재하지 않는 아이디로 로그인 한 경우
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/a65022d4-17f3-4883-9760-590feba06b9b)

비밀번호가 틀린 경우
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/b8aae85c-7b78-4763-b45d-deceb6305265)

### 💫 기타사항
