### PR TITLE
[BE] PATCH /post/:id 트랜잭션 개선, POST /post 트랜잭션 적용

### DIFF
--- a/packages/server/src/board/entities/image.entity.ts
+++ b/packages/server/src/board/entities/image.entity.ts
@@ -24,6 +24,9 @@ export class Image extends BaseEntity {
 	@Column({ type: 'int', nullable: false })
 	size: number;
 
+	@Column({ type: 'varchar', length: 50, nullable: false })
+	eTag: string;
+
 	@CreateDateColumn()
 	created_at: Date;
 


### PR DESCRIPTION
### 📎 이슈번호

- [08-10] 서버는 게시글 테이블(DB) 접근 시 필요하다면 트랜잭션을 적용한다. #112
- [08-09] 서버는 게시글 테이블(DB) 접근에 관한 에러를 처리한다. #111

### 📃 변경사항

- [x] PATCH /post/:id 트랜잭션 개선
  - [x] 계획
  - [x] 구현
  - [x] 동작 화면
- [x] POST /post 트랜잭션 적용
  - [x] 구현
  - [x] 동작 화면

### 🫨 고민한 부분

개발기록 참고

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

#### PATCH /post/:id 트랜잭션 개선

<img width="692" alt="스크린샷 2023-11-30 오후 2 15 39" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/64954681-519d-4fb4-ae99-650fe2880864">

<img width="1051" alt="스크린샷 2023-11-30 오후 2 16 15" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/900dedcb-921e-49a2-b7d9-dfc986132096">

이제 Image 삭제 및 새로 삽입하는 로직, 보드 수정 로직이 모두 하나의 트랜잭션에 들어간다. 성공!

#### POST /post 트랜잭션 적용

<img width="685" alt="스크린샷 2023-11-30 오후 2 14 36" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/96bd2252-cfcc-47fc-9f14-cc4be2c9f20a">

- before

<img width="1052" alt="스크린샷 2023-11-30 오후 1 23 21" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/e5dd8f07-d4f9-40b2-843d-39f1a29e325f">

- after

<img width="1052" alt="스크린샷 2023-11-30 오후 1 59 31" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/190d46cd-8b8d-49a5-8423-18614b98c9a3">

이제 Image와 Board 레코드의 생성 로직이 모두 한 트랜잭션에 들어간다. 성공!

### 💫 기타사항

- 개발 기록
  - [[재하] 1130(목) 개발기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%9E%AC%ED%95%98%5D-1130(%EB%AA%A9)-%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D)
