### PR TITLE
[FE] 글 작성 요청, 글 모달 스크롤바 구현

### DIFF
--- a/packages/client/src/app/Router.tsx
+++ b/packages/client/src/app/Router.tsx
@@ -10,7 +10,7 @@ import LoginModal from 'widgets/loginModal';
 import SignUpModal from 'widgets/signupModal/SignUpModal';
 import NickNameSetModal from 'widgets/nickNameSetModal/NickNameSetModal';
 import LogoAndStart from 'widgets/logoAndStart';
-import PostModal from 'features/postModal/PostModal';
+import { PostModal } from 'features/postModal';
 
 export const router = createBrowserRouter(
 	createRoutesFromElements(

--- a/packages/client/src/features/postModal/index.ts
+++ b/packages/client/src/features/postModal/index.ts
@@ -1,0 +1,1 @@
+export { default as PostModal } from './ui/PostModal';

--- a/packages/client/src/features/postModal/ui/ImageSlider.tsx
+++ b/packages/client/src/features/postModal/ui/ImageSlider.tsx
@@ -56,8 +56,6 @@ export default function ImageSlider({ imageUrls }: PropsType) {
 }
 
 const Layout = styled.div`
-	width: 500px;
-	height: 500px;
 	position: relative;
 `;
 

--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -33,10 +33,12 @@ export default function PostModal() {
 
 	const handleDelete = async () => {
 		const res = await deletePost(postId!);
+		setDeleteModal(false);
 		if (res.status === 200) {
-			setDeleteModal(false);
 			setView('MAIN');
 			navigate('/home');
+		} else {
+			alert('글 삭제 실패');
 		}
 	};
 

--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -8,8 +8,8 @@ import AlertDialog from 'shared/ui/alertDialog/AlertDialog';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFetch } from 'shared/hooks';
 import { PostData } from 'shared/lib/types/post';
-import { deletePost } from './api/deletePost';
-import ImageSlider from './ui/ImageSlider';
+import { deletePost } from '../api/deletePost';
+import ImageSlider from './ImageSlider';
 
 export default function PostModal() {
 	const { setView } = useViewStore();

--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -53,16 +53,18 @@ export default function PostModal() {
 						navigate(`/home/${postId}`);
 					}}
 				>
-					{data.images.length && (
-						<ImageContainer>
-							<ImageSlider imageUrls={data.images} />
-						</ImageContainer>
-					)}
-					<TextContainer>
-						<ReactMarkdown remarkPlugins={[remarkGfm]}>
-							{data.content}
-						</ReactMarkdown>
-					</TextContainer>
+					<Container>
+						{data.images.length && (
+							<ImageContainer>
+								<ImageSlider imageUrls={data.images} />
+							</ImageContainer>
+						)}
+						<TextContainer>
+							<ReactMarkdown remarkPlugins={[remarkGfm]}>
+								{data.content}
+							</ReactMarkdown>
+						</TextContainer>
+					</Container>
 				</PostModalLayout>
 				{deleteModal && (
 					<AlertDialog
@@ -85,10 +87,27 @@ const PostModalLayout = styled(Modal)`
 	transform: translate(-10%, -50%);
 `;
 
-const TextContainer = styled.div`
+const Container = styled.div`
+	height: 50vh;
 	overflow-y: auto;
-	width: 40vw;
 
+	&::-webkit-scrollbar {
+		width: 8px;
+	}
+
+	&::-webkit-scrollbar-track {
+		background-color: ${({ theme }) => theme.colors.text.primary};
+		border-radius: 8px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background-color: ${({ theme }) => theme.colors.text.third};
+		border-radius: 4px;
+	}
+`;
+
+const TextContainer = styled.div`
+	width: 40vw;
 	${({ theme: { colors } }) => ({
 		color: colors.text.secondary,
 	})}

--- a/packages/client/src/features/writingModal/api/sendPost.ts
+++ b/packages/client/src/features/writingModal/api/sendPost.ts
@@ -1,0 +1,34 @@
+import instance from 'shared/apis/AxiosInterceptor';
+import { BASE_URL } from '@constants';
+
+const dummyStarData = {
+	color: 'pink',
+	size: 200,
+	position: {
+		x: 1000,
+		y: 7000,
+		z: -1600,
+	},
+}; // TODO: 별 커스텀 데이터로 변경
+
+export const sendPost = async (text: string, files: FileList | null) => {
+	try {
+		const formData = new FormData();
+		formData.append('title', '제목');
+		formData.append('content', text);
+		formData.append('star', JSON.stringify(dummyStarData));
+		if (files) {
+			for (let i = 0; i < files.length; i++) formData.append('file', files[i]);
+		}
+
+		const response = await instance.post(`${BASE_URL}post`, formData, {
+			headers: {
+				'Content-Type': 'multipart/form-data',
+			},
+		});
+
+		return response;
+	} catch (err) {
+		console.error(err);
+	}
+};

--- a/packages/client/src/features/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/features/writingModal/ui/WritingModal.tsx
@@ -3,13 +3,23 @@ import { Button, Modal } from 'shared/ui';
 import TextArea from 'shared/ui/textArea/TextArea';
 import { ModalPortal } from 'shared/ui';
 import Images from './Images';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { sendPost } from '../api/sendPost';
 
 export default function WritingModal() {
 	const [text, setText] = useState('');
 	const [files, setFiles] = useState<FileList | null>(null);
 	const navigate = useNavigate();
+
+	const handleSendPost = async () => {
+		const response = await sendPost(text, files);
+		if (response!.status === 201) {
+			navigate('/home');
+			// TODO: home에서 별 정보 refetching
+		} else {
+			alert('글쓰기 실패');
+		}
+	};
 
 	return (
 		<ModalPortal>
@@ -17,7 +27,7 @@ export default function WritingModal() {
 				title="글쓰기"
 				rightButton={
 					<Button
-						onClick={() => sendToServer(text, files)}
+						onClick={handleSendPost}
 						size="m"
 						buttonType="CTA-icon"
 						type="submit"
@@ -33,27 +43,3 @@ export default function WritingModal() {
 		</ModalPortal>
 	);
 }
-
-const sendToServer = async (text: string, files: FileList | null) => {
-	try {
-		const formData = new FormData();
-		formData.append('title', 'title');
-		formData.append('text', text);
-		if (files)
-			for (let i = 0; i < files.length; i++) formData.append('image', files[i]);
-
-		const config = {
-			headers: {
-				'Content-Type': 'multipart/form-data',
-			},
-		};
-		const response = await axios.post(
-			`http://www.별글.site/board`,
-			formData,
-			config,
-		);
-		console.log(response);
-	} catch (error) {
-		console.log(error);
-	}
-};

--- a/packages/client/src/shared/apis/AxiosInterceptor.ts
+++ b/packages/client/src/shared/apis/AxiosInterceptor.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 const instance = axios.create({
 	baseURL: 'https://www.별글.site/api/',
+	withCredentials: true,
 });
 
 interface Props {

--- a/packages/client/src/shared/store/useViewStore.ts
+++ b/packages/client/src/shared/store/useViewStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-type view = 'MAIN' | 'DETAIL' | 'WRITING' | 'POST';
+type view = 'MAIN' | 'DETAIL' | 'POST';
 
 interface ViewState {
 	view: view;

--- a/packages/client/src/widgets/screen/index.tsx
+++ b/packages/client/src/widgets/screen/index.tsx
@@ -6,7 +6,7 @@ import { useControls } from 'leva';
 import { CAMERA_POSITION, CAMERA_FAR } from '@constants';
 import Controls from 'features/controls/Controls.tsx';
 import { useCameraStore } from 'shared/store/useCameraStore.ts';
-import { Posts } from 'entities/posts/index.ts';
+import { Posts } from 'entities/posts';
 
 export default function Screen() {
 	const camera = {


### PR DESCRIPTION
### 📎 이슈번호

#167 #192 

### 📃 변경사항

- 글 작성 요청 구현

### 🫨 고민한 부분

우선은 별 데이터를 그냥 더미 데이터로 두고 진행했습니다. 후에 별 커스텀 데이터로 변경하고, 글 작성완료시 home 화면에서 데이터 refetching도 필요할 것으로 보입니다. 지금은 새로고침으로 테스트했습니다.

### 📌 중점적으로 볼 부분

axios 인터셉터를 통해 글 작성 API 요청을 보내는 부분을 구현해줬습니다. CORS 에러가 또 나길래 인터셉터에도 `witCredentials true` 옵션을 추가해줬습니다.

글 모달에 스크롤바도 TextArea에서 구현한것과 동일하게 구현했습니다.

### 🎇 동작 화면
<img width="1476" alt="스크린샷 2023-11-30 오후 3 26 12" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/0cdc0ea7-201a-44fe-bba6-4c86da725c5e">
<img width="1476" alt="스크린샷 2023-11-30 오후 3 26 05" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/bfd51c26-65ad-49ff-8cd2-03dbdcc150df">
<img width="1476" alt="스크린샷 2023-11-30 오후 3 26 23" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/5988efa4-32ce-44e2-ad1f-7a97785118f8">
<img width="1476" alt="스크린샷 2023-11-30 오후 3 26 33" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/d69361cc-3d61-473c-a8db-12152f66615b">

https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/135fa7ea-08e8-4d46-9ef5-8eb20f2a8482

글 모달 스크롤바


### 💫 기타사항
잘되니까 기부니가 좋네요
글 작성 모달에 제목 Input도 하나 필요할 것 같습니다.
