### PR TITLE
[BE] 로그인 여부 확인 API 구현

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -41,6 +41,7 @@ import { StatusValidationPipe } from './pipes/StatusValidationPipe';
 import { ChangeStatusSwaggerDecorator } from './decorators/swagger/change-status-swagger.decorator';
 import { GetShareLinkSwaggerDecorator } from './decorators/swagger/get-share-link-swagger.decorator';
 import { LogInterceptor } from '../interceptor/log.interceptor';
+import { CheckSignInSwaggerDecorator } from './decorators/swagger/check-sign-in-swagger.decorator';
 
 @Controller('auth')
 @UseInterceptors(LogInterceptor)
@@ -77,6 +78,13 @@ export class AuthController {
 		});
 
 		return tokens;
+	}
+
+	@Get('check-signin')
+	@UseGuards(CookieAuthGuard)
+	@CheckSignInSwaggerDecorator()
+	async checkSignIn(@GetUser() userData: UserDataDto) {
+		return userData;
 	}
 
 	@Get('signout')

--- a/packages/server/src/auth/decorators/swagger/check-sign-in-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/check-sign-in-swagger.decorator.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiOkResponse,
+	ApiOperation,
+	ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '로그인 여부 확인',
+	description: '로그인 여부를 확인합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description:
+		'로그인 한 사용자가 맞음\n' + '응답으로 사용자 정보를 반환합니다.',
+};
+
+const apiUnauthorizedResponse = {
+	status: 401,
+	description: '로그인 하지 않은 사용자임',
+};
+
+export const CheckSignInSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiUnauthorizedResponse(apiUnauthorizedResponse),
+	);
+};


### PR DESCRIPTION
### 📎 이슈번호

- [04-10] 서버는 Auth Guard를 통해 특정 서비스를 인증된 사용자만 접근할 수 있도록 제한한다. #108 

### 📃 변경사항

로그인 여부 확인하는 checkSignIn Api 구현

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

스웨거에 api 설명 추가

![스크린샷 2023-12-01 오전 3 14 21](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/5296f771-f209-4703-b711-830516b8af48)

Postman으로 check-signin api 요청 테스트

![스크린샷 2023-12-01 오전 3 13 35](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/bdf20f56-6bec-482d-a681-627b117d017e)

1. 로그인을 한 사용자인 경우 -> 200 OK, 유저 정보 반환

![스크린샷 2023-12-01 오전 3 13 43](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/7b9411a3-0fb4-4a6c-b895-cf708fce19cb)

2. 로그인 하지 않은 사용자인 경우 -> 401 Unauthorized

![스크린샷 2023-12-01 오전 3 13 52](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/a4676330-1172-4a1a-a943-b32bbcf10835)


### 💫 기타사항
