### PR TITLE
[FE] 글 제목 입력 기능, 몇가지 버그 수정

### DIFF
--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -37,6 +37,7 @@ export default function PostModal() {
 		if (res.status === 200) {
 			setView('MAIN');
 			navigate('/home');
+			window.location.reload();
 		} else {
 			alert('글 삭제 실패');
 		}

--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -54,7 +54,7 @@ export default function PostModal() {
 					}}
 				>
 					<Container>
-						{data.images.length && (
+						{data.images.length > 0 && (
 							<ImageContainer>
 								<ImageSlider imageUrls={data.images} />
 							</ImageContainer>

--- a/packages/client/src/features/writingModal/api/sendPost.ts
+++ b/packages/client/src/features/writingModal/api/sendPost.ts
@@ -11,11 +11,15 @@ const dummyStarData = {
 	},
 }; // TODO: 별 커스텀 데이터로 변경
 
-export const sendPost = async (text: string, files: FileList | null) => {
+export const sendPost = async (
+	title: string,
+	content: string,
+	files: FileList | null,
+) => {
 	try {
 		const formData = new FormData();
-		formData.append('title', '제목');
-		formData.append('content', text);
+		formData.append('title', title);
+		formData.append('content', content);
 		formData.append('star', JSON.stringify(dummyStarData));
 		if (files) {
 			for (let i = 0; i < files.length; i++) formData.append('file', files[i]);

--- a/packages/client/src/features/writingModal/api/sendPost.ts
+++ b/packages/client/src/features/writingModal/api/sendPost.ts
@@ -18,8 +18,8 @@ export const sendPost = async (
 ) => {
 	try {
 		const formData = new FormData();
-		formData.append('title', title);
-		formData.append('content', content);
+		formData.append('title', title !== '' ? title : '제목 없음');
+		formData.append('content', content !== '' ? content : '내용 없음');
 		formData.append('star', JSON.stringify(dummyStarData));
 		if (files) {
 			for (let i = 0; i < files.length; i++) formData.append('file', files[i]);

--- a/packages/client/src/features/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/features/writingModal/ui/WritingModal.tsx
@@ -6,15 +6,17 @@ import Images from './Images';
 import { useNavigate } from 'react-router-dom';
 import { sendPost } from '../api/sendPost';
 import { useViewStore } from 'shared/store';
+import InputBar from 'shared/ui/inputBar/InputBar';
 
 export default function WritingModal() {
-	const [text, setText] = useState('');
+	const [title, setTitle] = useState('');
+	const [content, setContent] = useState('');
 	const [files, setFiles] = useState<FileList | null>(null);
 	const navigate = useNavigate();
 	const { setView } = useViewStore();
 
 	const handleSendPost = async () => {
-		const response = await sendPost(text, files);
+		const response = await sendPost(title, content, files);
 		if (response!.status === 201) {
 			navigate('/home');
 			// TODO: home에서 별 정보 refetching
@@ -43,7 +45,14 @@ export default function WritingModal() {
 					navigate('/home');
 				}}
 			>
-				<TextArea onChange={(text) => setText(text)} />
+				<InputBar
+					id={'postTitle'}
+					placeholder="제목"
+					style={{ marginBottom: '30px' }}
+					value={title}
+					onChange={(e) => setTitle(e.target.value)}
+				/>
+				<TextArea onChange={(content) => setContent(content)} height="40vh" />
 			</Modal>
 		</ModalPortal>
 	);

--- a/packages/client/src/features/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/features/writingModal/ui/WritingModal.tsx
@@ -19,7 +19,7 @@ export default function WritingModal() {
 		const response = await sendPost(title, content, files);
 		if (response!.status === 201) {
 			navigate('/home');
-			// TODO: home에서 별 정보 refetching
+			window.location.reload();
 		} else {
 			alert('글쓰기 실패');
 		}

--- a/packages/client/src/shared/ui/inputBar/InputBar.tsx
+++ b/packages/client/src/shared/ui/inputBar/InputBar.tsx
@@ -3,7 +3,7 @@ import theme from '../styles/theme';
 import { Body02ME, Body03ME } from '../styles';
 
 interface PropsType extends React.InputHTMLAttributes<HTMLInputElement> {
-	label: string;
+	label?: string;
 	id: string;
 	placeholder: string;
 	isEssential?: boolean;
@@ -18,10 +18,12 @@ export default function InputBar({
 }: PropsType) {
 	return (
 		<Container>
-			<LabelContainer>
-				<LabelText htmlFor={id}>{label}</LabelText>
-				{isEssential && <LabelStar>*</LabelStar>}
-			</LabelContainer>
+			{label && (
+				<LabelContainer>
+					<LabelText htmlFor={id}>{label}</LabelText>
+					{isEssential && <LabelStar>*</LabelStar>}
+				</LabelContainer>
+			)}
 
 			<Input id={id} placeholder={placeholder} {...args} />
 		</Container>

--- a/packages/client/src/shared/ui/textArea/TextArea.tsx
+++ b/packages/client/src/shared/ui/textArea/TextArea.tsx
@@ -8,15 +8,15 @@ import { Body04Me } from '../styles';
 
 interface PropsType {
 	onChange: (text: string) => void;
-	width?: number;
-	height?: number;
+	width?: string;
+	height?: string;
 	maxLength?: number;
 }
 
 export default function TextArea({
 	onChange,
-	width = 851,
-	height = 406,
+	width = '851px',
+	height = '406px',
 	maxLength = 1000,
 }: PropsType) {
 	const [tabIndex, setTabIndex] = useState(0);
@@ -71,10 +71,10 @@ export default function TextArea({
 	);
 }
 
-const Section = styled.section<{ width: number; height: number }>`
+const Section = styled.section<{ width: string; height: string }>`
 	${Body04Me}
-	width: ${({ width }) => width}px;
-	height: ${({ height }) => height}px;
+	width: ${({ width }) => width};
+	height: ${({ height }) => height};
 	background-color: ${theme.colors.background.bdp03};
 	color: ${theme.colors.text.third};
 	border-radius: 4px;


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 글쓰기 모달에 제목 입력 input 구현
- 이미지 개수 0일때 "0" 문자열 출력하던 버그 수정
- 제목 및 내용 빈 값 입력시 발생하던 버그 수정
- 리로딩 임시구현

### 🫨 고민한 부분

InputBar 컴포넌트 활용하여 제목 입력 input 구현해줬습니다.

---

<img width="369" alt="스크린샷 2023-12-02 오후 5 13 46" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/a8f8caf5-a06a-42c7-9ca0-4d2b2b5986ed">

원래는 `data.images.length > 0 && ... ` 이런식으로 구현되어있던 것을 위처럼 수정했었습니다. 문제는 저렇게 하니까 data.images.length가 0일때도 저 평가식이 참이 되더라구요? 😭 그래서 "0" 이라는 요상한 문자열이 출력되고 있었습니다. 그래서 그냥 이전처럼 `data.images.length > 0 && ... ` 방식으로 돌려놨습니다.

---

제목과 본문이 비어있을 때 서버에 요청하면 에러가 뜨는 버그를 발견했습니다. 비어있을 때 각각 "제목 없음", "내용 없음"을 기본값으로 서버에 전송하도록 해줬습니다.

---

글쓰기와 삭제시 임시로 그냥 리프레쉬 시키는 로직 넣어뒀습니다.

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/2128f8d9-ac8d-47fa-9c8b-4d8125f0f6f5

빈 제목 빈 내용으로 제출해도 글이 잘 작성되는 모습입니다. 위 영상을 보면 이미지가 없기 때문에 내용부분에 이상한 "0" 문자열이 보이는 것을 확인할 수 있습니다. 이젠 수정되었습니다 👍

### 💫 기타사항
