### PR TITLE
[BE] 쿠키 옵션 리팩토링 / User, ShareLink 엔티티 onDelete 옵션 추가 / GET /auth/sharelink API 버그 수정 / 공유링크로 Username 조회하는 GET /auth/sharelink/{link} API 구현

### DIFF
--- a/Dockerfile-was
+++ b/Dockerfile-was
@@ -4,7 +4,7 @@ WORKDIR /app
 
 ADD . /app
 
-RUN SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm_config_arch=x64 npm_config_platform=linux yarn workspace server add sharp
+RUN SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm_config_arch=x64 npm_config_platform=linux yarn workspace server add sharp@0.32.6
 RUN yarn workspace server build
 
 EXPOSE 3000

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -215,4 +215,9 @@ export class AuthController {
 	getShareLink(@GetUser() userData: UserDataDto) {
 		return this.authService.getShareLink(userData);
 	}
+
+	@Get('sharelink/:shareLink')
+	getUsernameByShareLink(@Param('shareLink') shareLink: string) {
+		return this.authService.getUsernameByShareLink(shareLink);
+	}
 }

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -21,7 +21,7 @@ import { AuthService } from './auth.service';
 import { SignUpUserDto } from './dto/signup-user.dto';
 import { User } from './entities/user.entity';
 import { SignInUserDto } from './dto/signin-user.dto';
-import { Response } from 'express';
+import { CookieOptions, Response } from 'express';
 import { ApiTags } from '@nestjs/swagger';
 import { JwtEnum } from './enums/jwt.enum';
 import { CookieAuthGuard } from './cookie-auth.guard';
@@ -42,6 +42,7 @@ import { ChangeStatusSwaggerDecorator } from './decorators/swagger/change-status
 import { GetShareLinkSwaggerDecorator } from './decorators/swagger/get-share-link-swagger.decorator';
 import { LogInterceptor } from '../interceptor/log.interceptor';
 import { CheckSignInSwaggerDecorator } from './decorators/swagger/check-sign-in-swagger.decorator';
+import { cookieOptionsConfig } from '../config/cookie.config';
 
 @Controller('auth')
 @UseInterceptors(LogInterceptor)
@@ -64,18 +65,16 @@ export class AuthController {
 		@Res({ passthrough: true }) res: Response,
 	) {
 		const tokens = await this.authService.signIn(signInUserDto);
-		res.cookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, tokens.accessToken, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'none',
-			secure: true,
-		});
-		res.cookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, tokens.refreshToken, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'none',
-			secure: true,
-		});
+		res.cookie(
+			JwtEnum.ACCESS_TOKEN_COOKIE_NAME,
+			tokens.accessToken,
+			cookieOptionsConfig,
+		);
+		res.cookie(
+			JwtEnum.REFRESH_TOKEN_COOKIE_NAME,
+			tokens.refreshToken,
+			cookieOptionsConfig,
+		);
 
 		return tokens;
 	}
@@ -95,18 +94,8 @@ export class AuthController {
 		@GetUser() userData: UserDataDto,
 	) {
 		await this.authService.signOut(userData);
-		res.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'none',
-			secure: true,
-		});
-		res.clearCookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'none',
-			secure: true,
-		});
+		res.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, cookieOptionsConfig);
+		res.clearCookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, cookieOptionsConfig);
 		return { message: UserEnum.SUCCESS_SIGNOUT_MESSAGE };
 	}
 
@@ -157,21 +146,20 @@ export class AuthController {
 			await this.authService.oauthCallback(service, authorizedCode, state);
 
 		if (username) {
-			res.cookie(`${service}Username`, username, {
-				path: '/',
-				httpOnly: true,
-			});
+			res.cookie(`${service}Username`, username, cookieOptionsConfig);
 			return { username };
 		}
 
-		res.cookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, accessToken, {
-			path: '/',
-			httpOnly: true,
-		});
-		res.cookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME, refreshToken, {
-			path: '/',
-			httpOnly: true,
-		});
+		res.cookie(
+			JwtEnum.ACCESS_TOKEN_COOKIE_NAME,
+			accessToken,
+			cookieOptionsConfig,
+		);
+		res.cookie(
+			JwtEnum.REFRESH_TOKEN_COOKIE_NAME,
+			refreshToken,
+			cookieOptionsConfig,
+		);
 
 		return { accessToken, refreshToken };
 	}
@@ -197,10 +185,7 @@ export class AuthController {
 			resourceServerUsername,
 		);
 
-		res.clearCookie(`${service}Username`, {
-			path: '/',
-			httpOnly: true,
-		});
+		res.clearCookie(`${service}Username`, cookieOptionsConfig);
 
 		return savedUser;
 	}

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import {
 	BadRequestException,
 	ConflictException,
 	Injectable,
+	InternalServerErrorException,
 	NotFoundException,
 	UnauthorizedException,
 } from '@nestjs/common';
@@ -224,12 +225,14 @@ export class AuthService {
 	}
 
 	async getShareLink(userData: UserDataDto) {
-		if (userData.status === UserShareStatus.PRIVATE) {
-			throw new BadRequestException('비공개 상태입니다.');
+		const user = await this.userRepository.findOneBy({ id: userData.userId });
+
+		if (user.status === UserShareStatus.PRIVATE) {
+			throw new UnauthorizedException('비공개 상태입니다.');
 		}
 
 		const foundLink = await this.shareLinkRepository.findOneBy({
-			user: userData.userId,
+			user: user.id,
 		});
 
 		if (foundLink) {
@@ -237,7 +240,7 @@ export class AuthService {
 		}
 
 		const newLink = this.shareLinkRepository.create({
-			user: userData.userId,
+			user: user.id,
 			link: uuid(),
 		});
 

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -248,4 +248,30 @@ export class AuthService {
 		savedLink.user = undefined;
 		return savedLink;
 	}
+
+	async getUsernameByShareLink(shareLink: string) {
+		const foundLink = await this.shareLinkRepository.findOneBy({
+			link: shareLink,
+		});
+
+		if (!foundLink) {
+			throw new NotFoundException('존재하지 않는 링크입니다.');
+		}
+
+		const linkUser = await this.userRepository.findOneBy({
+			id: foundLink.user,
+		});
+
+		if (!linkUser) {
+			throw new InternalServerErrorException(
+				'링크에 대한 사용자가 존재하지 않습니다.',
+			);
+		}
+
+		if (linkUser.status === UserShareStatus.PRIVATE) {
+			throw new UnauthorizedException('비공개 상태입니다.');
+		}
+
+		return linkUser.username;
+	}
 }

--- a/packages/server/src/auth/cookie-auth.guard.ts
+++ b/packages/server/src/auth/cookie-auth.guard.ts
@@ -8,6 +8,7 @@ import { JwtService } from '@nestjs/jwt';
 import { RedisRepository } from './redis.repository';
 import { createJwt } from '../util/auth.util';
 import { JwtEnum } from './enums/jwt.enum';
+import { cookieOptionsConfig } from '../config/cookie.config';
 
 @Injectable()
 export class CookieAuthGuard extends AuthGuard('jwt') {
@@ -41,8 +42,14 @@ export class CookieAuthGuard extends AuthGuard('jwt') {
 				this.jwtService.verify(refreshToken);
 			request.user = { userId, username, nickname, status };
 		} catch (error) {
-			response.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME);
-			response.clearCookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME);
+			response.clearCookie(
+				JwtEnum.ACCESS_TOKEN_COOKIE_NAME,
+				cookieOptionsConfig,
+			);
+			response.clearCookie(
+				JwtEnum.REFRESH_TOKEN_COOKIE_NAME,
+				cookieOptionsConfig,
+			);
 			throw new UnauthorizedException('로그인이 필요합니다.');
 		}
 
@@ -52,8 +59,14 @@ export class CookieAuthGuard extends AuthGuard('jwt') {
 				refreshToken,
 			))
 		) {
-			response.clearCookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME);
-			response.clearCookie(JwtEnum.REFRESH_TOKEN_COOKIE_NAME);
+			response.clearCookie(
+				JwtEnum.ACCESS_TOKEN_COOKIE_NAME,
+				cookieOptionsConfig,
+			);
+			response.clearCookie(
+				JwtEnum.REFRESH_TOKEN_COOKIE_NAME,
+				cookieOptionsConfig,
+			);
 			throw new UnauthorizedException('로그인이 필요합니다.');
 		}
 
@@ -67,10 +80,11 @@ export class CookieAuthGuard extends AuthGuard('jwt') {
 			JwtEnum.ACCESS_TOKEN_TYPE,
 			this.jwtService,
 		);
-		response.cookie(JwtEnum.ACCESS_TOKEN_COOKIE_NAME, newAccessToken, {
-			path: '/',
-			httpOnly: true,
-		});
+		response.cookie(
+			JwtEnum.ACCESS_TOKEN_COOKIE_NAME,
+			newAccessToken,
+			cookieOptionsConfig,
+		);
 		return true;
 	}
 }

--- a/packages/server/src/auth/entities/share_link.entity.ts
+++ b/packages/server/src/auth/entities/share_link.entity.ts
@@ -16,8 +16,8 @@ export class ShareLink {
 	link: string;
 
 	@OneToOne(() => User, (user) => user.id, {
-		onDelete: 'CASCADE',
 		eager: false,
+		onDelete: 'CASCADE',
 	})
 	@JoinColumn()
 	user: number;

--- a/packages/server/src/auth/entities/user.entity.ts
+++ b/packages/server/src/auth/entities/user.entity.ts
@@ -37,9 +37,15 @@ export class User {
 	@CreateDateColumn()
 	created_at: Date;
 
-	@OneToMany(() => Board, (board) => board.user, { eager: false })
+	@OneToMany(() => Board, (board) => board.user, {
+		eager: false,
+		onDelete: 'CASCADE',
+	})
 	boards: Board[];
 
-	@OneToOne(() => ShareLink, (shareLink) => shareLink.user)
+	@OneToOne(() => ShareLink, (shareLink) => shareLink.user, {
+		eager: false,
+		onDelete: 'SET NULL',
+	})
 	shareLink: ShareLink;
 }

--- a/packages/server/src/config/cookie.config.ts
+++ b/packages/server/src/config/cookie.config.ts
@@ -1,0 +1,8 @@
+import { CookieOptions } from 'express';
+
+export const cookieOptionsConfig: CookieOptions = {
+	path: '/',
+	httpOnly: true,
+	sameSite: 'none',
+	secure: true,
+};

--- a/packages/server/src/util/auth.util.ts
+++ b/packages/server/src/util/auth.util.ts
@@ -15,7 +15,6 @@ export async function createJwt(
 		userId: user.id,
 		username: user.username,
 		nickname: user.nickname,
-		status: user.status,
 		type,
 	};
 	const jwt = await jwtService.sign(payload, {


### PR DESCRIPTION
### 📎 이슈번호

- [10-03] 생성된 링크를 통한 GET 요청을 받으면, 인증 없이도 해당 은하를 탐험하고 별글을 확인할 수 있다. #70 

### 📃 변경사항

자주 사용되는 쿠키 옵션 cookie.config.ts로 분리

User, ShareLink 엔티티 사이에 onDelete 옵션 추가

로그인 하여 토큰을 발급받은 후 status를 변경하였을 때, getShareLink Api에서 변경 사항을 반영하도록 수정
원래는 토큰에 저장되어있던 status 정보를 읽어서 private인지 public인지 판단
-> status가 중간에 변경되어도 토큰은 그대로여서 반영하지 못했음
원래 토큰에 저장시켰던 status 정보 삭제, getShareLink에서 유저 데이터를 조회하도록 변경

getUsernameByShareLink Api 구현
`/auth/sharelink/{link}`로 조회하면 username 반환
만약 존재하지 않는 링크이거나, 링크에 대하여 유저 정보가 데이터베이스에 없는 경우, private인 유저인 경우 에러 반환

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

링크 조회
![스크린샷 2023-12-03 오후 2 46 36](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/e8adaf27-9a8e-469a-9884-f7acac02baa6)
![스크린샷 2023-12-03 오후 2 48 26](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/a6e3c5d9-ede1-46ea-a9e5-a890e505f170)

그 링크로 유저네임 조회
![스크린샷 2023-12-03 오후 2 46 43](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/402dfb94-96f3-4f37-845b-e4dbb398d9f2)
![스크린샷 2023-12-03 오후 2 46 55](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/00ebb340-0cc7-49b8-980e-b50c5477f0a8)

만약 private 상태로 바꾸면
![스크린샷 2023-12-03 오후 2 47 10](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/6cc8e501-68cb-4242-862e-dbaab1ae6767)
![스크린샷 2023-12-03 오후 2 47 08](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/a155587c-07e8-41f1-bb91-4cfad037402d)

에러 반환
![스크린샷 2023-12-03 오후 2 46 43](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/bbea607e-d511-4bb3-a41e-7126eba29e0c)
![스크린샷 2023-12-03 오후 2 47 15](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/c47186e4-d271-4bda-9937-e55fe04b7b8d)

### 💫 기타사항
