### PR TITLE
[FE] 검색 시 비슷한 닉네임 추천해주는 기능 구현

### DIFF
--- a/packages/client/src/pages/Home/ui/UpperBar.tsx
+++ b/packages/client/src/pages/Home/ui/UpperBar.tsx
@@ -4,6 +4,7 @@ import goBackIcon from '@icons/icon-back-32-white.svg';
 import { MAX_WIDTH1, MAX_WIDTH2 } from '@constants';
 import { useState, useEffect } from 'react';
 import { getNickNames } from 'shared/apis/search';
+import { useScreenSwitchStore } from 'shared/store/useScreenSwitchState';
 
 export default function UpperBar() {
 	const [searchValue, setSearchValue] = useState('');
@@ -36,6 +37,11 @@ export default function UpperBar() {
 		})();
 	}, [debouncedSearchValue]);
 
+	const handleSearchButton = () => {
+		// TODO: 해당 사용자 페이지로 이동
+		useScreenSwitchStore.setState({ isSwitching: true });
+	};
+
 	return (
 		<Layout>
 			<IconButton onClick={() => {}}>
@@ -43,7 +49,7 @@ export default function UpperBar() {
 			</IconButton>
 
 			<SearchBar
-				onClick={() => {}}
+				onClick={handleSearchButton}
 				inputState={searchValue}
 				setInputState={setSearchValue}
 				placeholder="닉네임을 입력하세요"

--- a/packages/client/src/pages/Home/ui/UpperBar.tsx
+++ b/packages/client/src/pages/Home/ui/UpperBar.tsx
@@ -2,10 +2,39 @@ import styled from '@emotion/styled';
 import { IconButton, Search } from 'shared/ui';
 import goBackIcon from '@icons/icon-back-32-white.svg';
 import { MAX_WIDTH1, MAX_WIDTH2 } from '@constants';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { getNickNames } from 'shared/apis/search';
 
 export default function UpperBar() {
-	const [temp, setTemp] = useState('');
+	const [searchValue, setSearchValue] = useState('');
+	const [debouncedSearchValue, setDebouncedSearchValue] = useState('');
+	const [searchResults, setSearchResults] = useState([]);
+
+	const DEBOUNCE_TIME = 200;
+
+	useEffect(() => {
+		const debounce = setTimeout(() => {
+			setDebouncedSearchValue(searchValue);
+		}, DEBOUNCE_TIME);
+
+		return () => clearTimeout(debounce);
+	}, [searchValue]);
+
+	useEffect(() => {
+		if (!debouncedSearchValue) {
+			setSearchResults([]);
+			return;
+		}
+
+		(async () => {
+			const nickNameDatas = await getNickNames(debouncedSearchValue);
+			const nickNames = nickNameDatas
+				.map((data: { nickname: string; id: number }) => data.nickname)
+				.slice(0, 5);
+
+			setSearchResults(nickNames);
+		})();
+	}, [debouncedSearchValue]);
 
 	return (
 		<Layout>
@@ -15,9 +44,10 @@ export default function UpperBar() {
 
 			<SearchBar
 				onClick={() => {}}
-				inputState={temp}
-				setInputState={setTemp}
+				inputState={searchValue}
+				setInputState={setSearchValue}
 				placeholder="닉네임을 입력하세요"
+				results={searchResults}
 			/>
 		</Layout>
 	);

--- a/packages/client/src/shared/apis/search.ts
+++ b/packages/client/src/shared/apis/search.ts
@@ -1,0 +1,10 @@
+import instance from './AxiosInterceptor';
+
+export const getNickNames = async (nickName: string) => {
+	const { data } = await instance({
+		method: 'GET',
+		url: `/auth/search?nickname=${nickName}`,
+	});
+
+	return data;
+};

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -16,7 +16,7 @@ export default function Search({
 	inputState,
 	setInputState,
 	placeholder = '',
-	results,
+	results = [],
 	...args
 }: PropsTypes) {
 	const onChangeSearchInput = ({
@@ -24,6 +24,10 @@ export default function Search({
 	}: React.ChangeEvent<HTMLInputElement>) => {
 		setInputState(target.value);
 	};
+
+	const resultsContents = results.map((result, index) => (
+		<Result key={index}>{result}</Result>
+	));
 
 	return (
 		<Layout {...args}>
@@ -47,13 +51,7 @@ export default function Search({
 				</Button>
 			</InputLayout>
 
-			{results && (
-				<ResultsLayout>
-					{results.map((result) => (
-						<Result>{result}</Result>
-					))}
-				</ResultsLayout>
-			)}
+			{results.length > 0 && <ResultsLayout>{resultsContents}</ResultsLayout>}
 		</Layout>
 	);
 }

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -6,6 +6,7 @@ import { Button } from 'shared/ui';
 interface PropsTypes {
 	onClick: () => void;
 	placeholder?: string;
+	results?: string[];
 	inputState: string;
 	setInputState: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -15,6 +16,7 @@ export default function Search({
 	inputState,
 	setInputState,
 	placeholder = '',
+	results,
 	...args
 }: PropsTypes) {
 	const onChangeSearchInput = ({
@@ -25,28 +27,32 @@ export default function Search({
 
 	return (
 		<Layout {...args}>
-			<img src={searchIcon} alt="돋보기 아이콘" />
+			<InputLayout>
+				<img src={searchIcon} alt="돋보기 아이콘" />
 
-			<SearchInput
-				placeholder={placeholder}
-				onChange={onChangeSearchInput}
-				value={inputState}
-			/>
+				<SearchInput
+					placeholder={placeholder}
+					onChange={onChangeSearchInput}
+					value={inputState}
+				/>
 
-			{inputState ? (
-				<Button onClick={onClick} size="m" buttonType="CTA-icon" type="submit">
-					버튼
-				</Button>
-			) : (
 				<Button
 					onClick={onClick}
 					size="m"
 					buttonType="CTA-icon"
 					type="submit"
-					disabled
+					disabled={!inputState}
 				>
 					버튼
 				</Button>
+			</InputLayout>
+
+			{results && (
+				<ResultsLayout>
+					{results.map((result) => (
+						<Result>{result}</Result>
+					))}
+				</ResultsLayout>
 			)}
 		</Layout>
 	);
@@ -54,17 +60,33 @@ export default function Search({
 
 const Layout = styled.div`
 	display: flex;
+	flex-direction: column;
 	justify-content: space-between;
 	align-items: center;
 	width: 100%;
 	border-radius: 8px;
 	padding: 8px;
+	gap: 8px;
+
 	background-color: ${({ theme: { colors } }) => colors.background.bdp01_80};
 	border: 1px solid ${({ theme: { colors } }) => colors.stroke.default};
 
 	:hover {
 		border: 1px solid ${({ theme: { colors } }) => colors.stroke.focus_80};
 	}
+`;
+
+const InputLayout = styled.div`
+	display: flex;
+	width: 100%;
+`;
+
+const ResultsLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	padding: 8px 0 0 24px;
+	border-top: 1px solid ${({ theme: { colors } }) => colors.stroke.default};
 `;
 
 const SearchInput = styled.input`
@@ -78,5 +100,19 @@ const SearchInput = styled.input`
 
 	::placeholder {
 		color: ${({ theme: { colors } }) => colors.text.disabled};
+	}
+`;
+
+const Result = styled.div`
+	display: flex;
+	padding: 8px 10px;
+	border-radius: 8px;
+	cursor: pointer;
+
+	color: ${({ theme: { colors } }) => colors.text.primary};
+	${Body03ME}
+
+	:hover {
+		background-color: ${({ theme: { colors } }) => colors.background.bdp02};
 	}
 `;


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- Search 컴포넌트에 옵셔널 props로 results를 받아서, results가 존재할 경우 검색바 아래 뜨도록 변경했습니다.
- API 호출 과다를 막기 위해, 사용자 입력이 0.2초간 멈춰있을 경우에 닉네임 목록을 불러오는 API를 호출하도록 했습니다. 
  - 디바운스 기법을 사용했습니다.
- 검색 버튼 클릭 시 로직은 아직 추가하지않았고, 페이지 전환 화면만 뜨도록 해두었습니다. 

### 🫨 고민한 부분
- 디바운스를 어떻게 적용할지
  - 디바운스와 스로틀링을 알고는 있었지만 직접 코드에 적용해본건 처음이네요. 블로그 여러개 참고하면서 해봤습니다.
  - 뭔가 이상하거나 잘못된 부분이 있다면 말씀해주세요 
- UpperBar 부분에서 Search 관련한 부분만 따로 분리할지 고민이네요.
  - ui/UpperBar.tsx를 구성하는 것 중 하나인 SearchBar.tsx도 ui/SearchBar.tsx처럼 UpperBar와 같은 계층에 넣어도 되는걸까요..? 
  - ui/upperBar/UpperBar.tsx, ui/upperBar/SearchBar.tsx와 같이 하는게 나을까영.. 의견부탁드려요  

### 📌 중점적으로 볼 부분
- UpperBar의 10-43번 라인

### 🎇 동작 화면
- 실제로는 닉네임 최대 5개까지만 보여줍니다. 동작을 보여주기 위해 잠시 제한을 풀었습니다.

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/e73e3e79-e7de-4e08-8a2a-a1c148ff1b2d

### 💫 기타사항
하핫 여기 카페에서 하는중인데 카페가좋네요 
오래걸릴줄 알았는데 생각보다 금방 끝나서 다행이에요 
https://map.naver.com/p/entry/place/1634513138?lng=126.9883525742605&lat=37.56861137965163&placePath=%2Fhome&entry=plt&c=15.00,0,0,0,dh