### PR TITLE
[FE] 우주 검색 기능 구현

### DIFF
--- a/packages/client/src/entities/posts/ui/Posts.tsx
+++ b/packages/client/src/entities/posts/ui/Posts.tsx
@@ -2,15 +2,34 @@ import { useFetch } from 'shared/hooks';
 import Post from './Post';
 import { useState } from 'react';
 import { StarData } from 'shared/lib/types/star';
+import { useOwnerStore } from 'shared/store/useOwnerStore';
+import { getPostListByNickName } from 'shared/apis/star';
+import { useEffect } from 'react';
 
 export default function Posts() {
 	const [post, setPost] = useState(0);
-	const { data } = useFetch<StarData[]>('star');
+	const [postData, setPostData] = useState<StarData[]>();
+
+	const { isMyPage, pageOwnerNickName } = useOwnerStore();
+
+	const myPostData = useFetch<StarData[]>('star').data;
+
+	useEffect(() => {
+		if (isMyPage) {
+			setPostData(myPostData);
+			return;
+		}
+
+		(async () => {
+			const otherPostData = await getPostListByNickName(pageOwnerNickName);
+			setPostData(otherPostData);
+		})();
+	}, [isMyPage, myPostData]);
 
 	return (
 		<>
-			{data &&
-				data.map((data, index) => (
+			{postData &&
+				postData.map((data, index) => (
 					<Post
 						key={index}
 						data={data}

--- a/packages/client/src/pages/Home/ui/UpperBar.tsx
+++ b/packages/client/src/pages/Home/ui/UpperBar.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import { getNickNames } from 'shared/apis/search';
 import { useScreenSwitchStore } from 'shared/store/useScreenSwitchStore';
 import { useOwnerStore } from 'shared/store/useOwnerStore';
+import Cookies from 'js-cookie';
 
 export default function UpperBar() {
 	const [searchValue, setSearchValue] = useState('');
@@ -14,6 +15,9 @@ export default function UpperBar() {
 
 	const { isMyPage, setIsMyPage } = useOwnerStore();
 	const { setIsSwitching } = useScreenSwitchStore();
+	const { setPageOwnerNickName } = useOwnerStore();
+
+	const userNickName = Cookies.get('nickname');
 
 	const DEBOUNCE_TIME = 200;
 
@@ -35,16 +39,15 @@ export default function UpperBar() {
 			const nickNameDatas = await getNickNames(debouncedSearchValue);
 			const nickNames = nickNameDatas
 				.map((data: { nickname: string; id: number }) => data.nickname)
+				.filter((nickName: string) => nickName !== userNickName)
 				.slice(0, 5);
-
-			// TODO: 본인 닉네임은 안뜨도록 하기
 
 			setSearchResults(nickNames);
 		})();
 	}, [debouncedSearchValue]);
 
-	const handleSearchButton = () => {
-		// TODO: 해당 사용자 페이지로 이동
+	const handleSearchButton = async () => {
+		setPageOwnerNickName(debouncedSearchValue);
 
 		setSearchValue('');
 		setDebouncedSearchValue('');
@@ -56,10 +59,15 @@ export default function UpperBar() {
 
 	const iconButtonVisibility = isMyPage ? 'hidden' : 'visible';
 
+	const handleGoBackButton = () => {
+		setIsMyPage(true);
+		setIsSwitching(true);
+	};
+
 	return (
 		<Layout>
 			<IconButton
-				onClick={() => {}}
+				onClick={handleGoBackButton}
 				style={{ visibility: iconButtonVisibility }}
 			>
 				<img src={goBackIcon} alt="뒤로가기" />

--- a/packages/client/src/shared/apis/login.ts
+++ b/packages/client/src/shared/apis/login.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosError } from 'axios';
-import { BASE_URL } from '@constants';
 import Cookies from 'js-cookie';
 import { NavigateFunction } from 'react-router-dom';
 import { useScreenSwitchStore } from 'shared/store/useScreenSwitchStore';
+import instance from './AxiosInterceptor';
 
 axios.defaults.withCredentials = true;
 
@@ -16,7 +16,10 @@ export const postLogin = async (
 	navigate: NavigateFunction,
 ) => {
 	try {
-		const res = await axios.post(BASE_URL + 'auth/signin', data, {
+		const res = await instance({
+			method: 'POST',
+			url: `/auth/signin`,
+			data,
 			withCredentials: true,
 		});
 
@@ -43,4 +46,13 @@ export const postLogin = async (
 			else alert(err);
 		} else alert(err);
 	}
+};
+
+export const getSignInInfo = async () => {
+	const { data } = await instance({
+		method: 'GET',
+		url: `/auth/check-signin`,
+	});
+
+	return data;
 };

--- a/packages/client/src/shared/apis/star.ts
+++ b/packages/client/src/shared/apis/star.ts
@@ -1,0 +1,10 @@
+import instance from './AxiosInterceptor';
+
+export const getPostListByNickName = async (nickName: string) => {
+	const { data } = await instance({
+		method: 'GET',
+		url: `/star/by-author?author=${nickName}`,
+	});
+
+	return data;
+};

--- a/packages/client/src/shared/store/useOwnerStore.ts
+++ b/packages/client/src/shared/store/useOwnerStore.ts
@@ -2,12 +2,19 @@ import { create } from 'zustand';
 
 interface OwnerState {
 	isMyPage: boolean;
+	pageOwnerNickName: string;
 	setIsMyPage: (value: boolean) => void;
+	setPageOwnerNickName: (value: string) => void;
 }
 
 export const useOwnerStore = create<OwnerState>((set) => ({
 	isMyPage: true,
+	pageOwnerNickName: '',
 	setIsMyPage: (value) => {
+		if (value === true) set((state) => ({ ...state, pageOwnerNickName: '' }));
 		set((state) => ({ ...state, isMyPage: value }));
+	},
+	setPageOwnerNickName: (value) => {
+		set((state) => ({ ...state, pageOwnerNickName: value }));
 	},
 }));

--- a/packages/client/src/shared/ui/search/Search.tsx
+++ b/packages/client/src/shared/ui/search/Search.tsx
@@ -26,7 +26,9 @@ export default function Search({
 	};
 
 	const resultsContents = results.map((result, index) => (
-		<Result key={index}>{result}</Result>
+		<Result key={index} onClick={() => setInputState(result)}>
+			{result}
+		</Result>
 	));
 
 	return (

--- a/packages/client/src/shared/ui/underBar/UnderBar.tsx
+++ b/packages/client/src/shared/ui/underBar/UnderBar.tsx
@@ -15,27 +15,30 @@ import { useViewStore } from 'shared/store';
 import { useOwnerStore } from 'shared/store/useOwnerStore';
 
 export default function UnderBar() {
-	const userName = Cookies.get('userId');
+	const nickName = Cookies.get('nickname');
 	const navigate = useNavigate();
+
 	const { setView } = useViewStore();
 	const { isMyPage } = useOwnerStore();
 
+	const handleLogoutButton = async () => {
+		await instance.get(`${BASE_URL}auth/signout`);
+
+		Cookies.remove('accessToken');
+		Cookies.remove('refreshToken');
+		Cookies.remove('userId');
+		Cookies.remove('nickname');
+
+		navigate('/');
+	};
+
 	return (
 		<Layout>
-			<Name>{userName}님의 은하</Name>
+			<Name>{nickName}님의 은하</Name>
 
 			<ButtonsContainer>
 				<SmallButtonsContainer>
-					<Button
-						size="m"
-						buttonType="Button"
-						onClick={async () => {
-							await instance.get(`${BASE_URL}auth/signout`);
-							Cookies.remove('accessToken');
-							Cookies.remove('refreshToken');
-							navigate('/');
-						}}
-					>
+					<Button size="m" buttonType="Button" onClick={handleLogoutButton}>
 						로그아웃
 					</Button>
 

--- a/packages/client/src/shared/ui/underBar/UnderBar.tsx
+++ b/packages/client/src/shared/ui/underBar/UnderBar.tsx
@@ -19,7 +19,7 @@ export default function UnderBar() {
 	const navigate = useNavigate();
 
 	const { setView } = useViewStore();
-	const { isMyPage } = useOwnerStore();
+	const { isMyPage, pageOwnerNickName } = useOwnerStore();
 
 	const handleLogoutButton = async () => {
 		await instance.get(`${BASE_URL}auth/signout`);
@@ -34,7 +34,7 @@ export default function UnderBar() {
 
 	return (
 		<Layout>
-			<Name>{nickName}님의 은하</Name>
+			<Name>{isMyPage ? nickName : pageOwnerNickName}님의 은하</Name>
 
 			<ButtonsContainer>
 				<SmallButtonsContainer>

--- a/packages/client/src/widgets/loginModal/index.tsx
+++ b/packages/client/src/widgets/loginModal/index.tsx
@@ -3,7 +3,7 @@ import { TopButton, LeftButton, RightButton, LoginContent } from './ui';
 import { useNavigate } from 'react-router-dom';
 import Cookies from 'js-cookie';
 import { useState } from 'react';
-import { postLogin } from 'shared/apis';
+import { getSignInInfo, postLogin } from 'shared/apis';
 import { useCheckLogin } from 'shared/hooks';
 
 export default function LoginModal() {
@@ -17,14 +17,17 @@ export default function LoginModal() {
 		return id.length && password.length && idState && passwordState;
 	};
 
-	const handleLoginSubmit = () => {
+	const handleLoginSubmit = async () => {
 		if (!isValid()) return;
 		const data = {
 			username: id,
 			password: password,
 		};
 		setPassword('');
-		postLogin(data, setIdState, setPasswordState, navigate);
+		await postLogin(data, setIdState, setPasswordState, navigate);
+
+		const { nickname } = await getSignInInfo();
+		Cookies.set('nickname', nickname);
 	};
 
 	useCheckLogin();


### PR DESCRIPTION
### 📎 이슈번호
#64 #66 

### 📃 변경사항
- 로그인 시 유저의 닉네임을 쿠키에 저장하도록 함
- useOwnerStore에 pageOwnerNickName 추가
  - 내 페이지가 아닐 경우, 다른 사용자의 닉네임을 저장함
  - 내 페이지로 돌아왔을 때 자동으로 빈문자열이 됨
- 검색 후 이동하면 글 내용이 해당 닉네임을 가진 사용자의 글들로 바뀜
- 다른 사람 우주에서 뒤로가기 버튼을 누르면 다시 내 글들로 바뀜
- 검색바 추천닉네임에 본인 닉네임은 뜨지 않도록 했습니다.

### 🫨 고민한 부분
- 우주 이동하는 부분을 어떻게 구현해야 할 지
  - 그냥 글 내용만 바꾸도록 했는데 다른 좋은 방법이 있을까요? 
  - 이후에 은하 바꾸는 기능도 넣게 되면.. 은하도 바꾸어야겠네요 

### 📌 중점적으로 볼 부분
- 검색 후 우주 이동하는 부분
- 남의 우주에서 다시 내 우주로 돌아오는 부분

### 🎇 동작 화면
- 이동 전에는 별이 있는데 이동 후에는 별이 없는 모습을 보여주기 위한 영상입니다
- 계속 영상크기때문에 안올라가서 몇 번을 다시 녹화햇네요 흐흑 굉장히 다급하게 찍었습니다

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/e10b9c42-ccb1-4a4b-9029-3dee23759ab6


### 💫 기타사항
- 점점 정신이 혼미해지는 상태에서 작성한 코드입니다.. 고쳐야 할게 많을수도있겠어요 얼레벌레 코드 🧑🏿‍🎤 피알 내일 올리려다가 정신을 가다듬고 올리고 잡니다

- 이후 해야 할 것
  - 검색했을 때 해당 닉네임이 존재하지 않으면 알럿창을 띄워야 합니다. 
  - 우주 이동 시 글 정보와 하단바, 상단바만 바뀌고 있습니다.  카메라의 시점을 원래대로 돌려놓는다거나 하는 추가적인 작업들이 필요합니다. 
