### PR TITLE
[FE] Leva 설정, 우주 배경색 변경

### DIFF
--- a/packages/client/src/widgets/galaxyCustom/ui/SampleScreen.tsx
+++ b/packages/client/src/widgets/galaxyCustom/ui/SampleScreen.tsx
@@ -19,7 +19,7 @@ export default function SampleScreen() {
 						luminanceSmoothing={0.025}
 					/>
 				</EffectComposer>
-				<color attach="background" args={['#000']} />
+				<color attach="background" args={['#070614']} />
 				<ambientLight color="#fff" intensity={5} />
 				<Galaxy number={2000} isCustom={true} />
 			</Canvas>

--- a/packages/client/src/widgets/landingScreen/index.tsx
+++ b/packages/client/src/widgets/landingScreen/index.tsx
@@ -38,7 +38,7 @@ export default function LandingScreen({
 					/>
 				</EffectComposer>
 
-				<color attach="background" args={['#000']} />
+				<color attach="background" args={['#070614']} />
 				<ambientLight color="#fff" intensity={5} />
 				<BackgroundStars />
 				<group rotation={[(mouseY - 0.5) / 5, (mouseX - 0.5) / 5, 0]}>

--- a/packages/client/src/widgets/screen/index.tsx
+++ b/packages/client/src/widgets/screen/index.tsx
@@ -44,7 +44,7 @@ export default function Screen() {
 					/>
 				</EffectComposer>
 
-				<color attach="background" args={['#000']} />
+				<color attach="background" args={['#070614']} />
 				<ambientLight color="#fff" intensity={5} />
 				<Controls />
 				<BackgroundStars />

--- a/packages/client/src/widgets/screen/index.tsx
+++ b/packages/client/src/widgets/screen/index.tsx
@@ -2,11 +2,12 @@ import { Canvas } from '@react-three/fiber';
 import BackgroundStars from 'features/backgroundStars';
 import { Galaxy } from '../galaxy';
 import { EffectComposer, Bloom } from '@react-three/postprocessing';
-import { useControls } from 'leva';
+import { Leva, useControls } from 'leva';
 import { CAMERA_POSITION, CAMERA_FAR } from '@constants';
 import Controls from 'features/controls/Controls.tsx';
 import { useCameraStore } from 'shared/store/useCameraStore.ts';
 import { Posts } from 'entities/posts';
+import styled from '@emotion/styled';
 
 export default function Screen() {
 	const camera = {
@@ -51,6 +52,17 @@ export default function Screen() {
 				<Galaxy />
 				<Posts />
 			</Canvas>
+			<LevaWrapper>
+				<Leva fill collapsed />
+			</LevaWrapper>
 		</div>
 	);
 }
+
+const LevaWrapper = styled.div`
+	position: absolute;
+	top: 5%;
+	right: 50%;
+	transform: translateX(50%);
+	z-index: 100;
+`;


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 우주 배경색 #070614로 변경
- Leva 컨트롤박스 디폴트로 접혀있게 설정
- Leva 초기 position 설정

### 🫨 고민한 부분

Leva 컴포넌트를 활용해 디폴트 설정들을 처리해주었습니다.

### 📌 중점적으로 볼 부분

Leva 컴포넌트, 우주 배경색

### 🎇 동작 화면

<img width="1582" alt="스크린샷 2023-12-04 오후 10 10 38" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/56d0ca0b-3a07-4aed-8735-bcd508025fce">

디폴트

<img width="1582" alt="스크린샷 2023-12-04 오후 10 10 41" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/831f704a-80ed-4d5f-b939-c55acc2d8b43">

open 시

### 💫 기타사항
