### PR TITLE
[FE] 별 라벨 디자인 변경

### DIFF
--- a/packages/client/src/entities/posts/ui/Post.tsx
+++ b/packages/client/src/entities/posts/ui/Post.tsx
@@ -17,8 +17,10 @@ interface PropsType {
 
 export default function Post({ data, onClick, isSelected }: PropsType) {
 	const { targetView, setTargetView } = useCameraStore();
-	const meshRef = useRef<THREE.Mesh>(null!);
 	const { view, setView } = useViewStore();
+
+	const meshRef = useRef<THREE.Mesh>(null!);
+
 	const navigate = useNavigate();
 
 	const handleMeshClick = (e: ThreeEvent<MouseEvent>) => {
@@ -56,22 +58,16 @@ export default function Post({ data, onClick, isSelected }: PropsType) {
 }
 
 const Label = styled.div`
-	transform: translate3d(calc(60%), calc(-70%), 0);
-	background: #fff;
-	color: #000;
+	transform: translate3d(calc(-50%), calc(-250%), 0); // TODO: 수정 예정
+	background-color: #fff;
+	opacity: 0.5;
 	padding: 10px 15px;
 	border-radius: 5px;
-	font-family: 'Noto Sans KR', sans-serif;
-	width: 200px;
+	width: fit-content;
+	max-width: 200px; // TODO: 수정 예정
 	text-align: center;
 
-	&::before {
-		content: '';
-		position: absolute;
-		top: 10px;
-		left: -100px;
-		height: 2px;
-		width: 100px;
-		background: #fff;
-	}
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 `;

--- a/packages/client/src/entities/posts/ui/Post.tsx
+++ b/packages/client/src/entities/posts/ui/Post.tsx
@@ -8,18 +8,20 @@ import { useViewStore } from 'shared/store/useViewStore';
 import * as THREE from 'three';
 import { StarData } from 'shared/lib/types/star';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import theme from 'shared/ui/styles/theme';
 
 interface PropsType {
 	data: StarData;
 	onClick: () => void;
-	isSelected: boolean;
 }
 
-export default function Post({ data, onClick, isSelected }: PropsType) {
+export default function Post({ data, onClick }: PropsType) {
 	const { targetView, setTargetView } = useCameraStore();
 	const { view, setView } = useViewStore();
 
 	const meshRef = useRef<THREE.Mesh>(null!);
+	const [isHovered, setIsHovered] = useState(false);
 
 	const navigate = useNavigate();
 
@@ -38,6 +40,16 @@ export default function Post({ data, onClick, isSelected }: PropsType) {
 		setView('POST');
 	};
 
+	const handlePointerOver = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setIsHovered(true);
+	};
+
+	const handlePointerOut = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setIsHovered(false);
+	};
+
 	return (
 		<Star
 			position={
@@ -47,8 +59,10 @@ export default function Post({ data, onClick, isSelected }: PropsType) {
 			color={data.color}
 			onClick={handleMeshClick}
 			ref={meshRef}
+			onPointerOver={handlePointerOver}
+			onPointerOut={handlePointerOut}
 		>
-			{view === 'DETAIL' && isSelected && (
+			{view === 'DETAIL' && isHovered && (
 				<Html>
 					<Label>{data.title}</Label>
 				</Html>
@@ -58,14 +72,15 @@ export default function Post({ data, onClick, isSelected }: PropsType) {
 }
 
 const Label = styled.div`
-	transform: translate3d(calc(-50%), calc(-250%), 0); // TODO: 수정 예정
-	background-color: #fff;
-	opacity: 0.5;
 	padding: 10px 15px;
 	border-radius: 5px;
 	width: fit-content;
 	max-width: 200px; // TODO: 수정 예정
 	text-align: center;
+	background-color: ${theme.colors.background.bdp01_80};
+	border: 1px solid ${theme.colors.stroke.sc};
+	color: ${theme.colors.text.secondary};
+	transform: translate3d(calc(-50%), calc(-250%), 0); // TODO: 수정 예정
 
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/client/src/features/star/index.tsx
+++ b/packages/client/src/features/star/index.tsx
@@ -6,14 +6,26 @@ import { useForwardRef } from 'shared/hooks';
 
 interface PropsType {
 	children?: React.ReactNode;
-	onClick?: (e: ThreeEvent<MouseEvent>) => void;
 	position: THREE.Vector3;
 	size: number;
 	color: string;
+	onClick?: (e: ThreeEvent<MouseEvent>) => void;
+	onPointerOver?: (e: React.MouseEvent) => void;
+	onPointerOut?: (e: React.MouseEvent) => void;
 }
 
 const Star = forwardRef<THREE.Mesh, PropsType>((props, ref) => {
 	const innerRef = useForwardRef(ref);
+
+	const {
+		children,
+		position,
+		size,
+		color,
+		onClick,
+		onPointerOver,
+		onPointerOut,
+	} = props;
 
 	useFrame((state) => {
 		const cameraDistance = innerRef.current.position.distanceTo(
@@ -29,14 +41,20 @@ const Star = forwardRef<THREE.Mesh, PropsType>((props, ref) => {
 	});
 
 	return (
-		<mesh ref={innerRef} position={props.position} onClick={props.onClick}>
-			<sphereGeometry args={[props.size, 32, 16]} />
+		<mesh
+			ref={innerRef}
+			position={position}
+			onClick={onClick}
+			onPointerOver={onPointerOver}
+			onPointerOut={onPointerOut}
+		>
+			<sphereGeometry args={[size, 32, 16]} />
 			<meshStandardMaterial
-				color={props.color}
-				emissive={props.color}
+				color={color}
+				emissive={color}
 				emissiveIntensity={2}
 			/>
-			{props.children}
+			{children}
 		</mesh>
 	);
 });


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 별의 라벨 디자인 변경
  - 라벨에는 글의 제목이 뜹니다. 
  - 하얀색이 촌스럽다는 익명의 백엔드1 의견과 border 색을 밝게 하면 좋겠다는 익명의 백엔드2 의견을 받아들였습니다. 🙏🏻
  - 라벨의 width가 200px이 넘어가면 말줄임표로 마무리됩니다. (일단은 200px로 해놓았는데 이후 별의 크기를 보고 수정 예정입니다.)
  - 폰트 크기같은 것들도 이후 별의 크기를 보고 변경할 예정입니다. 

- 별에 마우스 호버 시에만 라벨 보이도록 변경
  - 카메라에 가까워졌을 때 라벨이 보이도록 할지, 마우스를 호버했을 때 라벨이 보이도록 할지 고민했지만
  - 다수결의 법칙에 따라 호버 방식을 선택했읍니다. 🥹 
  - 이후에 카메라 기준으로 일정 범위 내에 존재하는 별들만 호버 시에 라벨이 보이도록 변경하면 좋을 것 같네요.
  - 이 과정에서 Star의 props로 onPointerOver, onPointerOut를 추가했습니다. 

### 🫨 고민한 부분
- 어떻게 별의 윗부분으로 라벨을 올릴지
  - 일단 퍼센트로 조절해서 하긴 했는데, 별 크기가 달라져도 그대로 유지될지는 잘 모르겠습니다.
  - 이후 별을 실제로 생성해보고 변경할 수도 있을 것 같네요.

- theme를 불러올 때 에러 발생
  - 왠지 모르겠는데 여기서만 에러가 발생하더라고요.. 
  - 프론트분들이 함께 있었으니 에러 메시지는 따로 첨부하지 않겠습니다 🕺🏼
  - 그래서 일단 theme를 직접 import해서 사용하고 있습니다.   

### 📌 중점적으로 볼 부분
라벨 디자인 부분

### 🎇 동작 화면
- 뭔가.....묘하게 불안정해보이네요....왜일까,,.

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/85bb72e5-dd07-419f-9549-e14499d0f567

### 💫 기타사항
사장님이 스콘을 서비스로 주셨으니 퇴근을 못하겠네요 
