### PR TITLE
[BE] admin 배포용 Dockerfile-Web 수정, cicd 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           yarn install
           yarn workspace client build
+          yarn workspace admin build
 
       - name: Build and Push Docker image
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vscode
+.DS_Store

--- a/Dockerfile-web
+++ b/Dockerfile-web
@@ -3,6 +3,7 @@ FROM nginx:alpine
 WORKDIR /usr/share/nginx/html
 
 ADD ./packages/client/dist /usr/share/nginx/html
+ADD ./packages/admin/dist /usr/share/nginx/html/admin
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,7 +35,13 @@ server {
         proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
         
         rewrite ^/api(/.*)$ $1 break;
-    }  
+    }
+
+    location /admin {
+        root /usr/share/nginx/html/admin;
+        index index.html;
+        try_files /admin$uri /admin$uri/ /admin/index.html;
+    }
 
     location ~* \.(?:manifest|appcache|html?|xml|json)$ {
       expires -1;
@@ -43,7 +49,7 @@ server {
     }
 
     location ~* \.(?:css|js)$ {
-      try_files $uri =404;
+      try_files $uri /admin$uri =404;
       expires 1y;
       access_log off;
       add_header Cache-Control "public";

--- a/packages/admin/.gitignore
+++ b/packages/admin/.gitignore
@@ -2,3 +2,4 @@ dist
 .vscode
 .idea
 .DS_Store
+node_modules

--- a/packages/admin/.gitignore
+++ b/packages/admin/.gitignore
@@ -1,0 +1,4 @@
+dist
+.vscode
+.idea
+.DS_Store

--- a/packages/admin/index.html
+++ b/packages/admin/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAC4UlEQVQ4jX2RyU8TYRiH3xmm7XScjQJV22kpi4WwGCCYmAhBIUIUCDF6IOofQKLGmLAYEFCxxIgePOBZPZl4cqlCRJYiMSiiIYRNBcsmloKdlmmnM0PrRRqowd/xy/c83/v+PiQcDkN0hhwzeucP/kIgoFgRBADHsUlzIv2goCjN/fnTHLkw7y3lPWKhShUjIdGCdwNf2emp1YblJd+zgF8eBQDQEuocI0dVGYzU+4V5b9maO/BR2Ag6TGa6Got+fW7u95mVn8LT5ptlo9uOP9xu65HCYbiyvMjXtdpOuNpaulmNBvOj2+G+nkkd7wkSfkH6Ei32eYNjwaAyXHg0UWmqs6MMg1fExmn7dwhcv4TD626h19ZRHooW2DrKQ4q06eA9UlN6RsLZ+AQtkZLKjEcEA30TqM8nmUVRmfmn1b/R7yOtE+OuYTEg5+43UC8zsy2hSAcsS6CKvKa0362QdhMIgqwTReWhKCrrHo9IAABEJvDyIgaAKLvBt1q61bIcSkMQwFEUoVEUEXcI/pfmBjtO0fhFI0c6jRzdybB4qslErQAARFaQZTCrVGh2NNxy9RWRoCdrTGZ6SqNBu7QEVpORpXucl5+iRCYY7J9mZ7+vn5PlTb6x1q7egq/V20n9XrI20cKMJaVQXY6+eUxRQhLPi/6tO+j01BI67/RWr7qEF7o4YgTHMSsAwPXG1xxnolsPpOm6qk7n9OTkpYZwHEsmSfXisZKsyDdjM5NrB1ddgrjhk0YT9ATrchHn22+8iTdbmEpLEttZfDxjFgCgqd6OGjm6OC5e+2T7iqjb7S/mefG5raM8NNjvRElSdcTI0adSrTrbFgwAQJLqLIbBxZLSzPXtAiwoKrgih8g7t96eNHD0IYOBfLS0tFE40Ou0dtu/jQIgoCVUOQYjVWm2UPeiS8bYWJzZQ6ovs6xmkDNRTbn5yRtDjpkRHI+pCfiVS4AAaLXYpMlE3S8oSvdEC/4A57MqjdH3GIkAAAAASUVORK5CYII=" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>별 하나에 글 하나 🌟</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -8,9 +8,9 @@ function App() {
 		<>
 			<Nav />
 			<Routes>
-				<Route path="/" element={<div>Home</div>} />
-				<Route path="/about" element={<div>About</div>} />
-				<Route path="/abc" element={<TestComponent />} />
+				<Route path="/admin/" element={<div>Home</div>} />
+				<Route path="/admin/about" element={<div>About</div>} />
+				<Route path="/admin/abc" element={<TestComponent />} />
 			</Routes>
 		</>
 	);

--- a/packages/admin/src/components/Nav.tsx
+++ b/packages/admin/src/components/Nav.tsx
@@ -2,9 +2,9 @@
 export const Nav = () => {
 	return (
 		<div>
-			<a href="/">Home</a>
-			<a href="/about">About</a>
-			<a href="/abc">Test</a>
+			<a href="/admin">Home</a>
+			<a href="/admin/about">About</a>
+			<a href="/admin/abc">Test</a>
 		</div>
 	);
 };


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

Dockerfile-Web에 admin dist폴더 전송 명령어 추가

GitHub Actions deploy.yml에 admin build 과정 추가

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

일단 /admin/index.html로 들어가면 제대로 실행되는 거 확인했습니다 ㅎㅎ
화면에 zz는 아래에 이유가 나옵니다.
![스크린샷 2023-12-05 오전 2 50 56](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/2cffdf9a-9b65-401b-819e-5dca997165b3)

근데 yarn workspace admin build하면 다음과 같이 저희가 작성한 코드는 빌드가 안되네요..
zz는 제가 그냥 테스트용으로 추가해놓은 겁니다!
![스크린샷 2023-12-05 오전 2 51 09](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/a97a527e-7474-494c-bb8f-1f674e126f21)

---

#### 위의 문제들 해결!!

- css, js 찾지 못한 문제 해결
/admin/assets/~~.js 이런 식으로 파일을 찾아와야 하는데, 그냥 /assets/~~.js 이런 식으로 찾아서 NotFound 에러가 발생
아래와 같이 nginx.conf를 수정하여 해결
```
location ~* \.(?:css|js)$ {
  try_files $uri /admin$uri =404;
  expires 1y;
  access_log off;
  add_header Cache-Control "public";
}
```
그냥 $uri(/assets/~~.js)로 못찾으면 /admin$uri(/admin/~~.js)로 찾음 -> 그래도 없으면 404

- 페이지 라우팅이 admin이 아닌 client로 가는 문제 해결
현재 테스트로 해놓은 Nav바에서 라우팅이 /, /about, /abc 이런 식으로 하다보니 링크 클릭을 하면 admin 페이지 내가 아닌 클라이언트 라우팅으로 감
Nav바 링크를 /admin, /admin/about, /admin/abc 이런 식으로 수정
```typescript
// nav바 컴포넌트
export const Nav = () => {
	return (
		<div>
			<a href="/admin">Home</a>
			<a href="/admin/about">About</a>
			<a href="/admin/abc">Test</a>
		</div>
	);
};
```
그러니 잘 됨!

https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/e7c25854-5e9f-4b23-9bad-e16fb17a0b72




### 💫 기타사항
