### PR TITLE
[BE] Exception Filter 구현 및 check-signin api 수정

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -21,7 +21,7 @@ import { AuthService } from './auth.service';
 import { SignUpUserDto } from './dto/signup-user.dto';
 import { User } from './entities/user.entity';
 import { SignInUserDto } from './dto/signin-user.dto';
-import { CookieOptions, Response } from 'express';
+import { Response } from 'express';
 import { ApiTags } from '@nestjs/swagger';
 import { JwtEnum } from './enums/jwt.enum';
 import { CookieAuthGuard } from './cookie-auth.guard';
@@ -84,7 +84,8 @@ export class AuthController {
 	@UseGuards(CookieAuthGuard)
 	@CheckSignInSwaggerDecorator()
 	async checkSignIn(@GetUser() userData: UserDataDto) {
-		return userData;
+		const user = await this.authService.findUserById(userData.userId);
+		return user;
 	}
 
 	@Get('signout')

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -43,6 +43,7 @@ import { GetShareLinkSwaggerDecorator } from './decorators/swagger/get-share-lin
 import { LogInterceptor } from '../interceptor/log.interceptor';
 import { CheckSignInSwaggerDecorator } from './decorators/swagger/check-sign-in-swagger.decorator';
 import { cookieOptionsConfig } from '../config/cookie.config';
+import { GetUsernameByShareLinkSwaggerDecorator } from './decorators/swagger/get-username-by-sharelink.decorator';
 
 @Controller('auth')
 @UseInterceptors(LogInterceptor)
@@ -216,6 +217,7 @@ export class AuthController {
 	}
 
 	@Get('sharelink/:shareLink')
+	@GetUsernameByShareLinkSwaggerDecorator()
 	getUsernameByShareLink(@Param('shareLink') shareLink: string) {
 		return this.authService.getUsernameByShareLink(shareLink);
 	}

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -37,6 +37,12 @@ export class AuthService {
 		private readonly redisRepository: RedisRepository,
 	) {}
 
+	async findUserById(id: number): Promise<User> {
+		const user = await this.userRepository.findOneBy({ id });
+		user.password = undefined;
+		return user;
+	}
+
 	async signUp(signUpUserDto: SignUpUserDto): Promise<Partial<User>> {
 		const { username, nickname } = signUpUserDto;
 		await Promise.all([

--- a/packages/server/src/auth/decorators/swagger/get-username-by-sharelink.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/get-username-by-sharelink.decorator.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiBadRequestResponse,
+	ApiInternalServerErrorResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '해당 공유링크를 가진 사용자의 닉네임 조회',
+	description: '해당 공유링크를 가진 사용자의 닉네임을 리턴합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description: '해당 공유링크를 가진 사용자의 닉네임 조회 성공',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '해당 공유링크를 가진 사용자가 없음',
+};
+
+const apiUnauthorizedResponse = {
+	status: 401,
+	description: '해당 유저는 비공개상태임',
+};
+
+const apiInternalServerErrorResponse = {
+	status: 500,
+	description: '링크에 대한 사용자가 존재하지 않음',
+};
+
+export const GetUsernameByShareLinkSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiUnauthorizedResponse(apiUnauthorizedResponse),
+		ApiInternalServerErrorResponse(apiInternalServerErrorResponse),
+	);
+};
+//

--- a/packages/server/src/exception-filter/http.exception-filter.ts
+++ b/packages/server/src/exception-filter/http.exception-filter.ts
@@ -10,23 +10,22 @@ export class HttpExceptionFilter {
 		const method = request.method;
 		const status = exception.getStatus();
 
-		try {
-			fs.readFileSync('./logs/exceptions.log').toString();
-		} catch (error) {
-			fs.mkdirSync('./logs');
-			fs.writeFileSync('./logs/exceptions.log', '');
+		const now = new Date();
+		const koreanTime = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+		const date = `${koreanTime.getFullYear()}-${
+			koreanTime.getMonth() + 1
+		}-${koreanTime.getDate()}`;
+		if (!fs.existsSync('./logs/exceptions')) {
+			fs.mkdirSync('./logs/exceptions', { recursive: true });
 		}
 
-		let log = `[${new Date().toISOString()}] [${method} ${request.url}] [${status} ${exception.name}] - ${exception.message}\n`;
+		let log = `[${koreanTime.toISOString()}] [${method} ${
+			request.url
+		}] [${status} ${exception.name}] - ${exception.message}\n`;
 		if (request.user) {
 			log = log.trim() + ` [${request.user.username}]\n`;
 		}
-		fs.appendFileSync(
-			'./logs/exceptions.log',
-			log,
-		);
-
-
+		fs.appendFileSync(`./logs/exceptions/${date}.log`, log);
 
 		response.status(status).json({
 			path: `${method} ${request.url}`,

--- a/packages/server/src/exception-filter/http.exception-filter.ts
+++ b/packages/server/src/exception-filter/http.exception-filter.ts
@@ -1,0 +1,19 @@
+import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+
+@Catch(HttpException)
+export class HttpExceptionFilter {
+	catch(exception: HttpException, host: ArgumentsHost) {
+		const context = host.switchToHttp();
+		const request = context.getRequest();
+		const response = context.getResponse();
+		const method = request.method;
+		const status = exception.getStatus();
+
+		response.status(status).json({
+			path: `${method} ${request.url}`,
+			error: `${status} ${exception.name}`,
+			message: exception.message,
+			timestamp: new Date().toISOString(),
+		});
+	}
+}

--- a/packages/server/src/exception-filter/http.exception-filter.ts
+++ b/packages/server/src/exception-filter/http.exception-filter.ts
@@ -1,4 +1,5 @@
 import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+import * as fs from 'fs';
 
 @Catch(HttpException)
 export class HttpExceptionFilter {
@@ -8,6 +9,24 @@ export class HttpExceptionFilter {
 		const response = context.getResponse();
 		const method = request.method;
 		const status = exception.getStatus();
+
+		try {
+			fs.readFileSync('./logs/exceptions.log').toString();
+		} catch (error) {
+			fs.mkdirSync('./logs');
+			fs.writeFileSync('./logs/exceptions.log', '');
+		}
+
+		let log = `[${new Date().toISOString()}] [${method} ${request.url}] [${status} ${exception.name}] - ${exception.message}\n`;
+		if (request.user) {
+			log = log.trim() + ` [${request.user.username}]\n`;
+		}
+		fs.appendFileSync(
+			'./logs/exceptions.log',
+			log,
+		);
+
+
 
 		response.status(status).json({
 			path: `${method} ${request.url}`,

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -2,11 +2,13 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
+import { HttpExceptionFilter } from './exception-filter/http.exception-filter';
 
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 
 	app.use(cookieParser());
+	app.useGlobalFilters(new HttpExceptionFilter());
 
 	// cors 허용
 	app.enableCors({


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

HttpExceptionFilter 추가
main.ts에 useGlobalFilter로 전역에 HttpExceptionFilter 적용

HttpException이 발생하면 에러 로그를 logs/exceptions/{날짜}.log 파일로 저장하도록 구현

check-signin api에서 데이터베이스를 조회해 현재 user status 정보도 반환 데이터에 포함되도록 수정

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

에러를 발생시키면
![스크린샷 2023-12-05 오후 2 03 53](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/c7f6fa87-0d0f-413f-b4ce-b3f074354d9a)

에러 로그가 남고
![스크린샷 2023-12-05 오후 2 04 02](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/c7d368fd-8cc9-4b9b-a847-fcca3ec08494)

packages/server/logs 폴더에 로그가 쌓임
![스크린샷 2023-12-05 오후 2 04 11](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/861c67c1-2223-4ce7-b48a-f3d88018d3a5)


### 💫 기타사항
