### PR TITLE
[BE] sharelink, search api 수정

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -244,8 +244,8 @@ export class AuthService {
 	async getShareLinkByNickname(nickname: string) {
 		const user = await this.userRepository.findOneBy({ nickname });
 
-		if (user.status === UserShareStatus.PRIVATE) {
-			throw new UnauthorizedException('비공개 상태입니다.');
+		if (!user) {
+			throw new NotFoundException('해당 유저를 찾을 수 없습니다.');
 		}
 
 		const foundLink = await this.shareLinkRepository.findOneBy({
@@ -283,10 +283,6 @@ export class AuthService {
 			throw new InternalServerErrorException(
 				'링크에 대한 사용자가 존재하지 않습니다.',
 			);
-		}
-
-		if (linkUser.status === UserShareStatus.PRIVATE) {
-			throw new UnauthorizedException('비공개 상태입니다.');
 		}
 
 		return linkUser.username;

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -219,6 +219,7 @@ export class AuthService {
 			.where(`MATCH (user.nickname) AGAINST (:nickname IN BOOLEAN MODE)`, {
 				nickname: nickname + '*',
 			})
+			.andWhere('user.status = :status', { status: UserShareStatus.PUBLIC })
 			.getMany();
 		return users;
 	}

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -243,6 +243,10 @@ export class AuthService {
 	}
 
 	async getShareLinkByNickname(nickname: string) {
+		if (!nickname) {
+			throw new BadRequestException('nickname을 입력해주세요.');
+		}
+
 		const user = await this.userRepository.findOneBy({ nickname });
 
 		if (!user) {

--- a/packages/server/src/auth/decorators/swagger/get-share-link-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/get-share-link-swagger.decorator.ts
@@ -1,6 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import {
 	ApiBadRequestResponse,
+	ApiNotFoundResponse,
 	ApiOkResponse,
 	ApiOperation,
 } from '@nestjs/swagger';
@@ -19,7 +20,12 @@ const apiOkResponse = {
 
 const apiBadRequestResponse = {
 	status: 400,
-	description: '유저가 비공개 상태임',
+	description: '쿼리스트링에 nickname을 입력하지 않음',
+};
+
+const apiNotFoundResponse = {
+	status: 404,
+	description: 'nickname에 해당하는 유저가 존재하지 않음',
 };
 
 export const GetShareLinkSwaggerDecorator = () => {
@@ -27,5 +33,6 @@ export const GetShareLinkSwaggerDecorator = () => {
 		ApiOperation(apiOperation),
 		ApiOkResponse(apiOkResponse),
 		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiNotFoundResponse(apiNotFoundResponse),
 	);
 };

--- a/packages/server/src/auth/decorators/swagger/get-username-by-sharelink.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/get-username-by-sharelink.decorator.ts
@@ -1,10 +1,9 @@
 import { applyDecorators } from '@nestjs/common';
 import {
-	ApiBadRequestResponse,
 	ApiInternalServerErrorResponse,
+	ApiNotFoundResponse,
 	ApiOkResponse,
 	ApiOperation,
-	ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 
 const apiOperation = {
@@ -17,14 +16,9 @@ const apiOkResponse = {
 	description: '해당 공유링크를 가진 사용자의 닉네임 조회 성공',
 };
 
-const apiBadRequestResponse = {
+const apiNotFoundResponse = {
 	status: 400,
 	description: '해당 공유링크를 가진 사용자가 없음',
-};
-
-const apiUnauthorizedResponse = {
-	status: 401,
-	description: '해당 유저는 비공개상태임',
 };
 
 const apiInternalServerErrorResponse = {
@@ -36,8 +30,7 @@ export const GetUsernameByShareLinkSwaggerDecorator = () => {
 	return applyDecorators(
 		ApiOperation(apiOperation),
 		ApiOkResponse(apiOkResponse),
-		ApiBadRequestResponse(apiBadRequestResponse),
-		ApiUnauthorizedResponse(apiUnauthorizedResponse),
+		ApiNotFoundResponse(apiNotFoundResponse),
 		ApiInternalServerErrorResponse(apiInternalServerErrorResponse),
 	);
 };

--- a/packages/server/src/auth/entities/user.entity.ts
+++ b/packages/server/src/auth/entities/user.entity.ts
@@ -30,7 +30,7 @@ export class User {
 		type: 'varchar',
 		length: 50,
 		nullable: true,
-		default: UserShareStatus.PRIVATE,
+		default: UserShareStatus.PUBLIC,
 	})
 	status: UserShareStatus;
 

--- a/packages/server/src/auth/enums/user.enum.ts
+++ b/packages/server/src/auth/enums/user.enum.ts
@@ -26,6 +26,5 @@ export enum UserEnum {
 
 export enum UserShareStatus {
 	PUBLIC = 'public',
-	ONLY_LINK = 'only_link',
 	PRIVATE = 'private',
 }

--- a/packages/server/src/auth/pipes/StatusValidationPipe.ts
+++ b/packages/server/src/auth/pipes/StatusValidationPipe.ts
@@ -2,11 +2,7 @@ import { BadRequestException, PipeTransform } from '@nestjs/common';
 import { UserShareStatus } from '../enums/user.enum';
 
 export class StatusValidationPipe implements PipeTransform {
-	readonly statusOptions = [
-		UserShareStatus.PRIVATE,
-		UserShareStatus.ONLY_LINK,
-		UserShareStatus.PUBLIC,
-	];
+	readonly statusOptions = [UserShareStatus.PRIVATE, UserShareStatus.PUBLIC];
 
 	transform(value: any) {
 		value = value.toLowerCase();


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

user.status가 private이어도 상관 없이 링크를 조회하도록 수정
status 기본값 public으로 변경
only_link 상태 삭제
StatusValidationPipe 수정
Swagger 수정

status가 public인 유저만 검색되도록 수정

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

검색 응답
![스크린샷 2023-12-05 오후 3 25 58](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/4048eff0-08ad-41ad-80f2-19e934addd8e)

유저 상태를 public으로 변경
![스크린샷 2023-12-05 오후 3 26 06](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/ae50d034-e348-49fe-b22e-2241924cb104)

검색 결과에 새로 포함된 모습
![스크린샷 2023-12-05 오후 3 26 11](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/8121b78f-9c10-4919-bee5-d059eb39a988)

### 💫 기타사항
