### PR TITLE
[FE] 글 수정 기능 구현

### DIFF
--- a/packages/client/src/entities/posts/ui/Post.tsx
+++ b/packages/client/src/entities/posts/ui/Post.tsx
@@ -36,8 +36,8 @@ export default function Post({ data, onClick }: PropsType) {
 			return;
 		}
 
-		navigate(`/home/${data.id}/detail`);
 		setView('POST');
+		navigate(`/home/${data.id}/detail`);
 	};
 
 	const handlePointerOver = (e: React.MouseEvent) => {

--- a/packages/client/src/features/postModal/ui/ImageSlider.tsx
+++ b/packages/client/src/features/postModal/ui/ImageSlider.tsx
@@ -61,6 +61,7 @@ export default function ImageSlider({ imageUrls }: PropsType) {
 
 const Layout = styled.div`
 	position: relative;
+	width: 18vw;
 `;
 
 const CurrentImage = styled.div`

--- a/packages/client/src/features/postModal/ui/PostModal.tsx
+++ b/packages/client/src/features/postModal/ui/PostModal.tsx
@@ -1,9 +1,9 @@
 import { useViewStore } from 'shared/store/useViewStore';
-import { Button, Modal, ModalPortal } from 'shared/ui';
+import { Button, Modal, ModalPortal, TextArea } from 'shared/ui';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AlertDialog from 'shared/ui/alertDialog/AlertDialog';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFetch } from 'shared/hooks';
@@ -11,13 +11,40 @@ import { PostData } from 'shared/lib/types/post';
 import { deletePost } from '../api/deletePost';
 import ImageSlider from './ImageSlider';
 import Like from 'entities/like/Like';
+import InputBar from 'shared/ui/inputBar/InputBar';
+import instance from 'shared/apis/AxiosInterceptor';
 
 export default function PostModal() {
 	const { setView } = useViewStore();
 	const [deleteModal, setDeleteModal] = useState(false);
 	const { postId } = useParams();
 	const navigate = useNavigate();
-	const { data } = useFetch<PostData>(`post/${postId}`);
+	const { data, refetch } = useFetch<PostData>(`post/${postId}`);
+	const [isEdit, setIsEdit] = useState(false);
+	const [content, setContent] = useState('');
+	const [title, setTitle] = useState('');
+
+	useEffect(() => {
+		setContent(data?.content ?? '');
+		setTitle(data?.title ?? '');
+	}, [data]);
+
+	const handleEditSave = async () => {
+		const formData = new FormData();
+		formData.append('title', title);
+		formData.append('content', content);
+		const res = await instance({
+			url: `/post/${postId}`,
+			method: 'PATCH',
+			data: formData,
+		});
+		if (res.status === 200) {
+			setIsEdit(false);
+			refetch();
+		} else {
+			alert('글 수정 실패');
+		}
+	};
 
 	const rightButton = (
 		<Button
@@ -29,6 +56,46 @@ export default function PostModal() {
 			}}
 		>
 			삭제
+		</Button>
+	);
+
+	const EditButton = (
+		<Button
+			size="m"
+			buttonType="CTA-icon"
+			type="button"
+			onClick={() => {
+				setIsEdit(true);
+			}}
+		>
+			수정하기
+		</Button>
+	);
+
+	const EditCancelButton = (
+		<Button
+			size="m"
+			buttonType="Button"
+			type="button"
+			onClick={() => {
+				setIsEdit(false);
+			}}
+		>
+			취소하기
+		</Button>
+	);
+
+	const EditSaveButton = (
+		<Button
+			size="m"
+			buttonType="CTA-icon"
+			type="button"
+			onClick={() => {
+				setIsEdit(false);
+				handleEditSave();
+			}}
+		>
+			저장하기
 		</Button>
 	);
 
@@ -48,25 +115,48 @@ export default function PostModal() {
 		data && (
 			<ModalPortal>
 				<PostModalLayout
-					title={data.title}
-					rightButton={rightButton}
+					title={isEdit ? '글 수정하기' : data.title}
+					rightButton={isEdit ? EditSaveButton : rightButton}
+					topButton={isEdit ? EditCancelButton : EditButton}
+					leftButton={
+						isEdit ? null : <Like postId={postId!} count={data.like_cnt ?? 0} />
+					}
 					onClickGoBack={() => {
 						setView('MAIN');
 						navigate(`/home/${postId}`);
 					}}
-					leftButton={<Like postId={postId!} count={data.like_cnt ?? 0} />}
 				>
 					<Container>
-						{data.images.length > 0 && (
+						{data.images.length > 0 && !isEdit && (
 							<ImageContainer>
 								<ImageSlider imageUrls={data.images} />
 							</ImageContainer>
 						)}
-						<TextContainer>
-							<ReactMarkdown remarkPlugins={[remarkGfm]}>
-								{data.content}
-							</ReactMarkdown>
-						</TextContainer>
+						{isEdit ? (
+							<TextContainer>
+								<InputBar
+									id={'postTitle'}
+									placeholder="제목"
+									style={{ marginBottom: '30px', height: '25%' }}
+									value={title}
+									onChange={(e) => setTitle(e.target.value)}
+								/>
+								<TextArea
+									value={content}
+									onChange={(content) => {
+										setContent(content);
+									}}
+									width="100%"
+									height="75%"
+								/>
+							</TextContainer>
+						) : (
+							<TextContainer>
+								<ReactMarkdown remarkPlugins={[remarkGfm]}>
+									{data.content}
+								</ReactMarkdown>
+							</TextContainer>
+						)}
 					</Container>
 				</PostModalLayout>
 				{deleteModal && (
@@ -111,6 +201,7 @@ const Container = styled.div`
 
 const TextContainer = styled.div`
 	width: 40vw;
+	height: 100%;
 	${({ theme: { colors } }) => ({
 		color: colors.text.secondary,
 	})}
@@ -118,8 +209,7 @@ const TextContainer = styled.div`
 
 const ImageContainer = styled.div`
 	display: flex;
+	align-items: center;
 	justify-content: center;
 	margin-bottom: 26px;
-	width: 100%;
-	height: 100%;
 `;

--- a/packages/client/src/shared/ui/textArea/TextArea.tsx
+++ b/packages/client/src/shared/ui/textArea/TextArea.tsx
@@ -11,6 +11,7 @@ interface PropsType {
 	width?: string;
 	height?: string;
 	maxLength?: number;
+	value?: string;
 }
 
 export default function TextArea({
@@ -18,9 +19,10 @@ export default function TextArea({
 	width = '851px',
 	height = '406px',
 	maxLength = 1000,
+	value = '',
 }: PropsType) {
 	const [tabIndex, setTabIndex] = useState(0);
-	const [text, setText] = useState('');
+	const [text, setText] = useState(value);
 	const isWrite = tabIndex === 0;
 	const isPreview = tabIndex === 1;
 
@@ -30,7 +32,7 @@ export default function TextArea({
 
 	const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		setText(e.currentTarget.value);
-		onChange(text);
+		onChange(e.currentTarget.value);
 	};
 
 	return (

--- a/packages/client/src/widgets/screen/index.tsx
+++ b/packages/client/src/widgets/screen/index.tsx
@@ -8,8 +8,10 @@ import Controls from 'features/controls/Controls.tsx';
 import { useCameraStore } from 'shared/store/useCameraStore.ts';
 import { Posts } from 'entities/posts';
 import styled from '@emotion/styled';
+import { useViewStore } from 'shared/store';
 
 export default function Screen() {
+	const { view } = useViewStore();
 	const camera = {
 		position: CAMERA_POSITION,
 		far: CAMERA_FAR,
@@ -53,7 +55,7 @@ export default function Screen() {
 				<Posts />
 			</Canvas>
 			<LevaWrapper>
-				<Leva fill collapsed />
+				<Leva fill collapsed hidden={view !== 'MAIN'} />
 			</LevaWrapper>
 		</div>
 	);


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 글 수정 기능 구현
- Leva 컨트롤박스 메인화면에서만 보이도록 수정
- 게시글에서 이미지 크기 조정

### 🫨 고민한 부분

isEdit state를 활용해 현재 수정중인지 판단합니다. 수정하기 버튼을 통해 수정상태로 진입하면 writingModal에서 구현했던것과 비슷하게 InputBar와 TextArea 컴포넌트를 활용해 수정할 내용들을 입력받고 서버로 전송하는 로직입니다.

기존의 데이터를 InputBar와 TextArea에 전달하기 위해 useEffect훅을 사용해줬습니다.

유저의 입력을 content state로 업데이트하는 부분에서, 계속해서 마지막 글자가 짤리는 현상이 발생했는데, [#128 ](https://github.com/boostcampwm2023/web16-B1G1/pull/128#discussion_r1401658180)에서 @KimGaeun0806 님이 지적해주신 부분때문이었습니다 ㅎㅎ 바로 생각나서 금방 고칠 수 있었습니다 감사해요 👍

### 📌 중점적으로 볼 부분

PostModal.tsx

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/9de2dd49-3513-4217-a1e4-d61acb36cee9

### 💫 기타사항

PostModal이 너무 길어져서 좀 분리가 필요해보이긴합니다
