### PR TITLE
[FE] 은하 커스텀 화면

### DIFF
--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -9,12 +9,24 @@ import instance from 'shared/apis/AxiosInterceptor';
 import { useScreenSwitchStore } from 'shared/store/useScreenSwitchStore';
 import Cookies from 'js-cookie';
 import { getSignInInfo } from 'shared/apis';
+import { getGalaxy } from 'shared/apis';
+import { useGalaxyStore } from 'shared/store';
 
 export default function Home() {
 	const { view } = useViewStore();
 	const { isSwitching } = useScreenSwitchStore();
 	const navigate = useNavigate();
 	const [nickName, setNickName] = useState('');
+	const {
+		spiral,
+		setSpiral,
+		start,
+		setStart,
+		thickness,
+		setThickness,
+		zDist,
+		setZDist,
+	} = useGalaxyStore();
 
 	useEffect(() => {
 		const checkLogin = async () => {
@@ -35,6 +47,13 @@ export default function Home() {
 		getSignInInfo().then((res) => {
 			Cookies.set('nickname', res.nickname);
 			setNickName(res.nickname);
+		});
+		getGalaxy(nickName).then((res) => {
+			if (res.spiral && res.spiral !== spiral) setSpiral(res.spiral);
+			if (res.start && res.start !== start) setStart(res.start);
+			if (res.thickness && res.thickness !== thickness)
+				setThickness(res.thickness);
+			if (res.zDist && res.zDist !== zDist) setZDist(res.zDist);
 		});
 	}, []);
 

--- a/packages/client/src/shared/apis/galaxy.ts
+++ b/packages/client/src/shared/apis/galaxy.ts
@@ -1,0 +1,27 @@
+import instance from './AxiosInterceptor';
+
+export const getGalaxy = async (nickname: string) => {
+	if (nickname !== '') {
+		const { data } = await instance({
+			method: 'GET',
+			url: `/galaxy/by-nickname?nickname=${nickname}`,
+		});
+		return data;
+	}
+	const { data } = await instance({
+		method: 'GET',
+		url: `/galaxy`,
+	});
+
+	return data;
+};
+
+export const postGalaxy = async (galaxyStyle: Object) => {
+	const { data } = await instance({
+		method: 'PATCH',
+		url: `/galaxy`,
+		data: galaxyStyle,
+	});
+
+	return data;
+};

--- a/packages/client/src/shared/apis/index.ts
+++ b/packages/client/src/shared/apis/index.ts
@@ -1,3 +1,4 @@
 export * from './AxiosInterceptor';
 export * from './signUp';
 export * from './login';
+export * from './galaxy';

--- a/packages/client/src/shared/store/useCustomStore.ts
+++ b/packages/client/src/shared/store/useCustomStore.ts
@@ -3,8 +3,6 @@ import { create } from 'zustand';
 interface CustomState {
 	spiral: number;
 	setSpiral: (value: number) => void;
-	density: number;
-	setDensity: (value: number) => void;
 	start: number;
 	setStart: (value: number) => void;
 	thickness: number;
@@ -16,8 +14,6 @@ interface CustomState {
 export const useCustomStore = create<CustomState>((set) => ({
 	spiral: 1.2,
 	setSpiral: (value: number) => set({ spiral: value }),
-	density: 0.5,
-	setDensity: (value: number) => set({ density: value }),
 	start: 1000,
 	setStart: (value: number) => set({ start: value }),
 	thickness: 300,

--- a/packages/client/src/shared/store/useGalaxyStore.ts
+++ b/packages/client/src/shared/store/useGalaxyStore.ts
@@ -4,14 +4,11 @@ import {
 	GALAXY_THICKNESS,
 	SPIRAL,
 	SPIRAL_START,
-	STARS_DENSITY,
 } from 'widgets/galaxy/lib/constants';
 
 interface GalaxyState {
 	spiral: number;
 	setSpiral: (value: number) => void;
-	density: number;
-	setDensity: (value: number) => void;
 	start: number;
 	setStart: (value: number) => void;
 	thickness: number;
@@ -23,8 +20,6 @@ interface GalaxyState {
 export const useGalaxyStore = create<GalaxyState>((set) => ({
 	spiral: SPIRAL,
 	setSpiral: (value: number) => set({ spiral: value }),
-	density: STARS_DENSITY,
-	setDensity: (value: number) => set({ density: value }),
 	start: SPIRAL_START,
 	setStart: (value: number) => set({ start: value }),
 	thickness: GALAXY_THICKNESS,

--- a/packages/client/src/widgets/galaxy/lib/modules/instances.tsx
+++ b/packages/client/src/widgets/galaxy/lib/modules/instances.tsx
@@ -1,8 +1,13 @@
 import * as THREE from 'three';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { DISTANCE_LIMIT } from '../constants';
-import { getSpiralPositions, getSpherePositions } from '.';
+import { DISTANCE_LIMIT, STARS_DENSITY } from '../constants';
+import {
+	getSpiralPositions,
+	getSpherePositions,
+	setSpiralPositions,
+	setSpherePositions,
+} from '.';
 import { useGalaxyStore, useCustomStore } from 'shared/store';
 
 interface PropsType {
@@ -21,18 +26,33 @@ export default function Instances({ count, size, color, isCustom }: PropsType) {
 		emissiveIntensity: 2,
 	});
 	const tempObject = new THREE.Object3D();
-	const { density, zDist, thickness, spiral, start } = isCustom
+	const { zDist, thickness, spiral, start } = isCustom
 		? useCustomStore()
 		: useGalaxyStore();
+	const arms = count * STARS_DENSITY;
+	const center = count - arms;
+
+	let [spiralPositions, spherePositions] = useMemo(() => {
+		const spirals = [];
+		const spheres = [];
+		for (let i = 0; i < arms; i++) {
+			const position = getSpiralPositions();
+			spirals.push(position);
+		}
+		for (let i = 0; i < center; i++) {
+			const position = getSpherePositions();
+			spheres.push(position);
+		}
+		return [spirals, spheres];
+	}, []);
 
 	useEffect(() => {
-		const arms = count * density;
-		const center = count - arms;
 		let index = 0;
 
 		for (let i = 0; i < arms; i++) {
 			tempObject.position.copy(
-				getSpiralPositions({
+				setSpiralPositions({
+					position: spiralPositions[i],
 					z_dist: zDist,
 					thickness: thickness,
 					spiral: spiral,
@@ -43,12 +63,14 @@ export default function Instances({ count, size, color, isCustom }: PropsType) {
 			instancedMeshRef.current.setMatrixAt(index++, tempObject.matrix);
 		}
 		for (let i = 0; i < center; i++) {
-			tempObject.position.copy(getSpherePositions(thickness));
+			tempObject.position.copy(
+				setSpherePositions(spherePositions[i], thickness),
+			);
 			tempObject.updateMatrix();
 			instancedMeshRef.current.setMatrixAt(index++, tempObject.matrix);
 		}
 		instancedMeshRef.current.instanceMatrix.needsUpdate = true;
-	}, []);
+	}, [zDist, thickness, spiral, start]);
 
 	useFrame(({ camera: { position } }) => {
 		const cameraDistance = new THREE.Vector3(0, 0, 0).distanceTo(position);

--- a/packages/client/src/widgets/galaxy/lib/modules/positions.ts
+++ b/packages/client/src/widgets/galaxy/lib/modules/positions.ts
@@ -3,21 +3,42 @@ import * as THREE from 'three';
 import { ARMS_X_DIST } from '../constants';
 
 interface GalaxyInfo {
+	position: THREE.Vector3;
 	z_dist: number;
 	thickness: number;
 	spiral: number;
 	spiral_start: number;
 }
 
-export const getSpiralPositions = ({
+export const getSpiralPositions = () => {
+	const x = getGaussianRandomFloat(0, ARMS_X_DIST);
+	const y = getGaussianRandomFloat(0, 1);
+	const z = getGaussianRandomFloat(0, 1);
+	return new THREE.Vector3(x, y, z);
+};
+
+export const getSpherePositions = () => {
+	const x = getRandomFloat(0, Math.PI * 2);
+	const y = getGaussianRandomFloat(0, Math.PI / 5);
+	const r = getGaussianRandomFloat(0, 1);
+
+	return new THREE.Vector3(
+		r * Math.sin(x) * Math.cos(y) * ARMS_X_DIST,
+		r * Math.sin(y) * 4,
+		r * Math.cos(x) * Math.cos(y) * ARMS_X_DIST,
+	);
+};
+
+export const setSpiralPositions = ({
+	position,
 	z_dist,
 	thickness,
 	spiral,
 	spiral_start,
 }: GalaxyInfo) => {
-	const x = getGaussianRandomFloat(0, ARMS_X_DIST);
-	const y = getGaussianRandomFloat(0, thickness);
-	const z = getGaussianRandomFloat(0, z_dist);
+	const x = position.x;
+	const y = position.y * thickness;
+	const z = position.z * z_dist;
 	const r = Math.sqrt(x ** 2 + z ** 2);
 	if (r < spiral_start) return new THREE.Vector3(x, y, z);
 
@@ -27,14 +48,13 @@ export const getSpiralPositions = ({
 	return new THREE.Vector3(x, y, z).applyAxisAngle(yAxis, theta);
 };
 
-export const getSpherePositions = (thickness: number) => {
-	const x = getRandomFloat(0, Math.PI * 2);
-	const y = getGaussianRandomFloat(0, Math.PI / 5);
-	const r = getGaussianRandomFloat(0, 1);
+export const setSpherePositions = (
+	position: THREE.Vector3,
+	thickness: number,
+) => {
+	const x = position.x;
+	const y = position.y * thickness;
+	const z = position.z;
 
-	return new THREE.Vector3(
-		r * Math.sin(x) * Math.cos(y) * ARMS_X_DIST,
-		r * Math.sin(y) * thickness * 4,
-		r * Math.cos(x) * Math.cos(y) * ARMS_X_DIST,
-	);
+	return new THREE.Vector3(x, y, z);
 };

--- a/packages/client/src/widgets/galaxyCustom/index.tsx
+++ b/packages/client/src/widgets/galaxyCustom/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useViewStore } from 'shared/store';
 import styled from '@emotion/styled';
 import { useGalaxyStore, useCustomStore } from 'shared/store';
+import { postGalaxy } from 'shared/apis';
 
 export default function GalaxyCustom() {
 	const navigate = useNavigate();
@@ -18,10 +19,27 @@ export default function GalaxyCustom() {
 	const { spiral, start, thickness, zDist } = useCustomStore();
 
 	const handleSubmit = () => {
-		if (galaxy.spiral !== spiral) galaxy.setSpiral(spiral);
-		if (galaxy.start !== start) galaxy.setStart(start);
-		if (galaxy.thickness !== thickness) galaxy.setThickness(thickness);
-		if (galaxy.zDist !== zDist) galaxy.setZDist(zDist);
+		const galaxyStyle: { [key: string]: number } = {};
+
+		if (galaxy.spiral !== spiral) {
+			galaxy.setSpiral(spiral);
+			galaxyStyle.spiral = spiral;
+		}
+		if (galaxy.start !== start) {
+			galaxy.setStart(start);
+			galaxyStyle.start = start;
+		}
+		if (galaxy.thickness !== thickness) {
+			galaxy.setThickness(thickness);
+			galaxyStyle.thickness = thickness;
+		}
+		if (galaxy.zDist !== zDist) {
+			galaxy.setZDist(zDist);
+			galaxyStyle.zDist = zDist;
+		}
+		if (Object.keys(galaxyStyle).length !== 0) {
+			postGalaxy(galaxyStyle);
+		}
 	};
 
 	return (

--- a/packages/client/src/widgets/galaxyCustom/index.tsx
+++ b/packages/client/src/widgets/galaxyCustom/index.tsx
@@ -29,6 +29,8 @@ export default function GalaxyCustom() {
 			onSubmit={(e) => {
 				e.preventDefault();
 				handleSubmit();
+				navigate('/home');
+				setView('MAIN');
 			}}
 		>
 			<Modal

--- a/packages/client/src/widgets/galaxyCustom/index.tsx
+++ b/packages/client/src/widgets/galaxyCustom/index.tsx
@@ -14,16 +14,14 @@ import { useGalaxyStore, useCustomStore } from 'shared/store';
 export default function GalaxyCustom() {
 	const navigate = useNavigate();
 	const { setView } = useViewStore();
-	const { setSpiral, setDensity, setStart, setThickness, setZDist } =
-		useGalaxyStore();
-	const { spiral, density, start, thickness, zDist } = useCustomStore();
+	const galaxy = useGalaxyStore();
+	const { spiral, start, thickness, zDist } = useCustomStore();
 
 	const handleSubmit = () => {
-		setSpiral(spiral);
-		setDensity(density);
-		setStart(start);
-		setThickness(thickness);
-		setZDist(zDist);
+		if (galaxy.spiral !== spiral) galaxy.setSpiral(spiral);
+		if (galaxy.start !== start) galaxy.setStart(start);
+		if (galaxy.thickness !== thickness) galaxy.setThickness(thickness);
+		if (galaxy.zDist !== zDist) galaxy.setZDist(zDist);
 	};
 
 	return (

--- a/packages/client/src/widgets/galaxyCustom/ui/LeftButton.tsx
+++ b/packages/client/src/widgets/galaxyCustom/ui/LeftButton.tsx
@@ -3,20 +3,26 @@ import { useCustomStore } from 'shared/store';
 import {
 	SPIRAL,
 	SPIRAL_START,
-	STARS_DENSITY,
 	ARMS_Z_DIST,
 	GALAXY_THICKNESS,
 } from 'widgets/galaxy/lib/constants';
 
 export default function LeftButton() {
-	const { setSpiral, setStart, setDensity, setZDist, setThickness } =
-		useCustomStore();
+	const {
+		spiral,
+		setSpiral,
+		start,
+		setStart,
+		zDist,
+		setZDist,
+		thickness,
+		setThickness,
+	} = useCustomStore();
 	const handleClick = () => {
-		setSpiral(SPIRAL);
-		setStart(SPIRAL_START);
-		setDensity(STARS_DENSITY);
-		setZDist(ARMS_Z_DIST);
-		setThickness(GALAXY_THICKNESS);
+		if (spiral !== SPIRAL) setSpiral(SPIRAL);
+		if (start !== SPIRAL_START) setStart(SPIRAL_START);
+		if (zDist !== ARMS_Z_DIST) setZDist(ARMS_Z_DIST);
+		if (thickness !== GALAXY_THICKNESS) setThickness(GALAXY_THICKNESS);
 	};
 	return (
 		<Button

--- a/packages/client/src/widgets/galaxyCustom/ui/Sliders.tsx
+++ b/packages/client/src/widgets/galaxyCustom/ui/Sliders.tsx
@@ -8,8 +8,6 @@ export default function Sliders() {
 		setSpiral,
 		start,
 		setStart,
-		density,
-		setDensity,
 		zDist,
 		setZDist,
 		thickness,
@@ -40,14 +38,6 @@ export default function Sliders() {
 				step={100}
 				value={start}
 				setValue={setStart}
-			/>
-			<Slider
-				id="별 응집도"
-				min={0.05}
-				max={0.95}
-				step={0.05}
-				value={density}
-				setValue={setDensity}
 			/>
 			<Slider
 				id="은하 높이"

--- a/packages/client/src/widgets/galaxyCustom/ui/TopButton.tsx
+++ b/packages/client/src/widgets/galaxyCustom/ui/TopButton.tsx
@@ -3,15 +3,13 @@ import { useCustomStore, useGalaxyStore } from 'shared/store';
 import { RotateCcw } from 'lucide-react';
 
 export default function TopButton() {
-	const { setSpiral, setStart, setDensity, setZDist, setThickness } =
-		useCustomStore();
-	const { spiral, start, density, zDist, thickness } = useGalaxyStore();
+	const custom = useCustomStore();
+	const { spiral, start, zDist, thickness } = useGalaxyStore();
 	const handleClick = () => {
-		setSpiral(spiral);
-		setStart(start);
-		setDensity(density);
-		setZDist(zDist);
-		setThickness(thickness);
+		if (custom.spiral !== spiral) custom.setSpiral(spiral);
+		if (custom.start !== start) custom.setStart(start);
+		if (custom.zDist !== zDist) custom.setZDist(zDist);
+		if (custom.thickness !== thickness) custom.setThickness(thickness);
 	};
 
 	return (


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 은하 커스텀의 실시간 보기 기능을 활성화 했다

### 🫨 고민한 부분
이 문제를 어떻게 해결해야 하나
왜 안되는지 이해가 가지 않는 문제라 해결책을 찾는것 자체가 문제였다

### 📌 중점적으로 볼 부분
멋진 커스텀 화면

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/78800560/4d778ae5-73e3-4ecf-91f8-047c3485469a

### 💫 기타사항
