### PR TITLE
[BE] OAuth2.0 통한 회원가입 시 Galaxy Record 생성

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -200,10 +200,16 @@ export class AuthService {
 
 		this.redisRepository.del(resourceServerUsername);
 
+		// galaxy도 default로 MongoDB에 저장 후 id 반환
+		const galaxyDoc = new this.starModel({});
+		await galaxyDoc.save();
+		const galaxy_id: string = galaxyDoc._id.toString();
+
 		const newUser: User = this.userRepository.create({
 			username: resourceServerUsername,
 			password: uuid(),
 			nickname,
+			galaxy: galaxy_id,
 		});
 
 		const savedUser: User = await this.userRepository.save(newUser);


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- OAuth2.0을 통한 회원가입 시 galaxy record가 생성되지 않는 문제 버그 픽스
- signUpwithOAuth 메소드에도 해당 로직 추가

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항
