### PR TITLE
[BE] sentiment, board 모듈 e2e 테스트 코드 작성, 테스트, 코드 개선

### DIFF
--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -52,13 +52,13 @@ export class BoardController {
 	@UseInterceptors(TransactionInterceptor)
 	@UsePipes(ValidationPipe)
 	@CreateBoardSwaggerDecorator()
-	createBoard(
+	async createBoard(
 		@Body() createBoardDto: CreateBoardDto,
 		@GetUser() userData: UserDataDto,
 		@UploadedFiles() files: Express.Multer.File[],
 		@GetQueryRunner() queryRunner: QueryRunner,
 	): Promise<Board> {
-		return this.boardService.createBoard(
+		return await this.boardService.createBoard(
 			createBoardDto,
 			userData,
 			files,
@@ -97,7 +97,7 @@ export class BoardController {
 		@Param('id', ParseIntPipe) id: number,
 		@GetUser() userData: UserDataDto,
 	): Promise<boolean> {
-		return this.boardService.getIsLiked(id, userData);
+		return await this.boardService.getIsLiked(id, userData);
 	}
 
 	// 사진도 수정할 수 있도록 폼데이터 형태로 받기
@@ -107,14 +107,14 @@ export class BoardController {
 	@UseInterceptors(TransactionInterceptor)
 	@UsePipes(ValidationPipe)
 	@UpdateBoardSwaggerDecorator()
-	updateBoard(
+	async updateBoard(
 		@Param('id', ParseIntPipe) id: number,
 		@Body() updateBoardDto: UpdateBoardDto,
 		@GetUser() userData: UserDataDto,
 		@UploadedFiles() files: Express.Multer.File[],
 		@GetQueryRunner() queryRunner: QueryRunner,
 	) {
-		return this.boardService.updateBoard(
+		return await this.boardService.updateBoard(
 			id,
 			updateBoardDto,
 			userData,
@@ -127,22 +127,22 @@ export class BoardController {
 	@UseGuards(CookieAuthGuard)
 	@UsePipes(ValidationPipe)
 	@PatchLikeSwaggerDecorator()
-	patchLike(
+	async patchLike(
 		@Param('id', ParseIntPipe) id: number,
 		@GetUser() userData: UserDataDto,
 	): Promise<Partial<Board>> {
-		return this.boardService.patchLike(id, userData);
+		return await this.boardService.patchLike(id, userData);
 	}
 
 	@Patch(':id/unlike')
 	@UseGuards(CookieAuthGuard)
 	@UsePipes(ValidationPipe)
 	@PatchUnlikeSwaggerDecorator()
-	patchUnlike(
+	async patchUnlike(
 		@Param('id', ParseIntPipe) id: number,
 		@GetUser() userData: UserDataDto,
 	): Promise<Partial<Board>> {
-		return this.boardService.patchUnlike(id, userData);
+		return await this.boardService.patchUnlike(id, userData);
 	}
 
 	// 연관된 Image 및 Star, Like도 함께 삭제
@@ -151,11 +151,11 @@ export class BoardController {
 	@UseInterceptors(TransactionInterceptor)
 	@UsePipes(ValidationPipe)
 	@DeleteBoardSwaggerDecorator()
-	deleteBoard(
+	async deleteBoard(
 		@Param('id', ParseIntPipe) id: number,
 		@GetUser() userData: UserDataDto,
 		@GetQueryRunner() queryRunner: QueryRunner,
 	): Promise<DeleteResult> {
-		return this.boardService.deleteBoard(id, userData, queryRunner);
+		return await this.boardService.deleteBoard(id, userData, queryRunner);
 	}
 }

--- a/packages/server/src/board/board.service.ts
+++ b/packages/server/src/board/board.service.ts
@@ -120,7 +120,7 @@ export class BoardService {
 		files: Express.Multer.File[],
 		queryRunner: QueryRunner,
 	) {
-		await queryRunner.startTransaction();
+		// await queryRunner.startTransaction();
 
 		const board: Board = await queryRunner.manager.findOneBy(Board, { id });
 		if (!board) {
@@ -174,7 +174,7 @@ export class BoardService {
 
 		delete updatedBoard.user.password; // password 제거하여 반환
 
-		await queryRunner.commitTransaction();
+		// await queryRunner.commitTransaction();
 		return updatedBoard;
 	}
 
@@ -247,7 +247,7 @@ export class BoardService {
 		userData: UserDataDto,
 		queryRunner: QueryRunner,
 	): Promise<DeleteResult> {
-		await queryRunner.startTransaction();
+		// await queryRunner.startTransaction();
 
 		const board: Board = await queryRunner.manager.findOneBy(Board, { id });
 
@@ -278,7 +278,7 @@ export class BoardService {
 		// 게시글 삭제
 		const result = await queryRunner.manager.delete(Board, { id });
 
-		await queryRunner.commitTransaction();
+		// await queryRunner.commitTransaction();
 		return result;
 	}
 

--- a/packages/server/src/board/entities/board.entity.ts
+++ b/packages/server/src/board/entities/board.entity.ts
@@ -3,12 +3,10 @@ import {
 	Column,
 	CreateDateColumn,
 	Entity,
-	JoinColumn,
 	JoinTable,
 	ManyToMany,
 	ManyToOne,
 	OneToMany,
-	OneToOne,
 	PrimaryGeneratedColumn,
 	UpdateDateColumn,
 } from 'typeorm';

--- a/packages/server/src/sentiment/sentiment.service.ts
+++ b/packages/server/src/sentiment/sentiment.service.ts
@@ -1,11 +1,16 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+	BadRequestException,
+	Injectable,
+	InternalServerErrorException,
+} from '@nestjs/common';
 import { GetSentimentDto } from './dto/get-sentiment.dto';
-import { clovaConfig } from 'src/config/clova.config';
+import { clovaConfig } from '../config/clova.config';
 
 @Injectable()
 export class SentimentService {
 	async getSentiment(body: GetSentimentDto) {
 		const { content } = body;
+		if (!content) throw new BadRequestException('게시글 내용이 없습니다.');
 
 		const response = await fetch(clovaConfig.url, {
 			method: 'POST',

--- a/packages/server/test/sentiment/sentiment.e2e-spec.ts
+++ b/packages/server/test/sentiment/sentiment.e2e-spec.ts
@@ -1,0 +1,35 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('SentimentController', () => {
+	let app: INestApplication;
+
+	beforeEach(async () => {
+		const moduleFixture = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		app = moduleFixture.createNestApplication();
+		await app.init();
+	});
+
+	it('should be defined', () => {
+		expect(app).toBeDefined();
+	});
+
+	it('POST /sentiment', async () => {
+		const response = await request(app.getHttpServer())
+			.post('/sentiment')
+			.send({ content: 'test' })
+			.expect(200);
+
+		expect(response).toHaveProperty('body');
+		const { body } = response;
+		expect(body).toHaveProperty('color');
+		const { color } = body;
+		expect(typeof color).toBe('string');
+		expect(color.startsWith('#')).toBe(true);
+	});
+});


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- [x] e2e 테스트 코드 작성, 테스트
  - [x] board 모듈
  - [x] sentiment 모듈
  - [x] 리팩토링, 코드 개선

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

- async/await가 제대로 적용되지 않은 비동기 로직들로 인해 테스트 시 어떨 때는 통과되고, 어떨 때는 통과가 되지 않는 문제들이 발생함
  - 컨트롤러 단의 필요한 메소드를 async로, service를 await해줌으로써 response 후 결과가 반영되는 문제 해결
  - transaction interceptor의 commitTransaction()이 response 후에 적용되는 문제(POST /post 등)는 아직 해결 못함 

### 🎇 동작 화면

#### sentiment

<img width="423" alt="스크린샷 2023-12-07 오후 4 42 36" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/0b9bd35a-5817-4ba7-98c4-8640b9a136b4">

#### board (transaction interceptor on)

<img width="736" alt="스크린샷 2023-12-07 오후 7 34 29" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/1adb31a9-4d77-422d-a33d-5e8661ee0dfd">

#### board (transaction interceptor off)

<img width="671" alt="스크린샷 2023-12-07 오후 6 33 21" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/c729951d-15c9-453e-a9aa-c7c20a53c981">

### 💫 기타사항

- 개발 기록
  - [[재하] 1207(목) 개발기록](https://github.com/boostcampwm2023/web16-B1G1/wiki/%5B%EC%9E%AC%ED%95%98%5D-1207(%EB%AA%A9)-%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D)
