### PR TITLE
[BE] galaxy, sentiment 서비스 유닛 테스트

### DIFF
--- a/packages/server/test/galaxy/galaxy.service.spec.ts
+++ b/packages/server/test/galaxy/galaxy.service.spec.ts
@@ -1,18 +1,156 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GalaxyService } from '../../src/galaxy/galaxy.service';
+import { Repository } from 'typeorm';
+import { User } from '../../src/auth/entities/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getModelToken } from '@nestjs/mongoose';
+import { Galaxy } from '../../src/galaxy/schemas/galaxy.schema';
+import { Model } from 'mongoose';
+import {
+	BadRequestException,
+	InternalServerErrorException,
+	NotFoundException,
+} from '@nestjs/common';
 
 describe('GalaxyService', () => {
 	let service: GalaxyService;
+	let userRepository: Repository<User>;
+	let galaxyModel: Model<Galaxy>;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [GalaxyService],
+			providers: [
+				GalaxyService,
+				{
+					provide: getRepositoryToken(User),
+					useClass: Repository,
+				},
+				{
+					provide: getModelToken(Galaxy.name),
+					useValue: Model,
+				},
+			],
 		}).compile();
 
 		service = module.get<GalaxyService>(GalaxyService);
+		userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+		galaxyModel = module.get<Model<Galaxy>>(getModelToken(Galaxy.name));
 	});
 
 	it('should be defined', () => {
 		expect(service).toBeDefined();
+	});
+
+	describe('findGalaxyByNickname', () => {
+		it('should throw BadRequestException with empty nickname', async () => {
+			await expect(service.findGalaxyByNickname('')).rejects.toThrow(
+				'nickname is required',
+			);
+			await expect(service.findGalaxyByNickname('')).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw NotFoundException with not existed user', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(undefined);
+
+			await expect(service.findGalaxyByNickname('nickname')).rejects.toThrow(
+				'user not found',
+			);
+			await expect(service.findGalaxyByNickname('nickname')).rejects.toThrow(
+				NotFoundException,
+			);
+		});
+
+		it('should throw NotFoundException with not existed galaxy', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(new User());
+
+			jest.spyOn(galaxyModel, 'findOne').mockResolvedValue(undefined);
+
+			await expect(service.findGalaxyByNickname('nickname')).rejects.toThrow(
+				'galaxy not found',
+			);
+			await expect(service.findGalaxyByNickname('nickname')).rejects.toThrow(
+				NotFoundException,
+			);
+		});
+
+		it('should return galaxy', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(new User());
+
+			jest.spyOn(galaxyModel, 'findOne').mockResolvedValue(new Galaxy());
+
+			await expect(service.findGalaxyByNickname('nickname')).resolves.toEqual(
+				new Galaxy(),
+			);
+		});
+	});
+
+	describe('updateGalaxyMine', () => {
+		it('should throw NotFoundException with not existed user', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(undefined);
+
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				'user not found',
+			);
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				NotFoundException,
+			);
+		});
+
+		it('should throw InternalServerErrorException with update failed', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(new User());
+
+			jest.spyOn(galaxyModel, 'updateOne').mockResolvedValue(undefined);
+
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				'galaxy update failed',
+			);
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				InternalServerErrorException,
+			);
+		});
+
+		it('should throw NotFoundException with not existed galaxy', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(new User());
+
+			jest.spyOn(galaxyModel, 'updateOne').mockResolvedValue({
+				acknowledged: true,
+				matchedCount: 0,
+				upsertedId: null,
+				upsertedCount: 0,
+				modifiedCount: 0,
+			});
+
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				'galaxy not found',
+			);
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				NotFoundException,
+			);
+		});
+
+		it('should throw BadRequestException with nothing to update', async () => {
+			jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(new User());
+
+			jest.spyOn(galaxyModel, 'updateOne').mockResolvedValue({
+				acknowledged: true,
+				matchedCount: 1,
+				upsertedId: null,
+				upsertedCount: 0,
+				modifiedCount: 0,
+			});
+
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				'nothing to update',
+			);
+			await expect(service.updateGalaxyMine({}, { userId: 1 })).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
 	});
 });

--- a/packages/server/test/sentiment/sentiment.service.spec.ts
+++ b/packages/server/test/sentiment/sentiment.service.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SentimentService } from '../../src/sentiment/sentiment.service';
+import {
+	BadRequestException,
+	InternalServerErrorException,
+} from '@nestjs/common';
 
 describe('SentimentService', () => {
 	let service: SentimentService;
@@ -10,9 +14,64 @@ describe('SentimentService', () => {
 		}).compile();
 
 		service = module.get<SentimentService>(SentimentService);
+
+		// jest.mock('fetch');
 	});
 
 	it('should be defined', () => {
 		expect(service).toBeDefined();
+	});
+
+	describe('getSentiment', () => {
+		it('should throw BadRequestException with empty content', async () => {
+			await expect(service.getSentiment({ content: '' })).rejects.toThrow(
+				'content is required',
+			);
+
+			await expect(service.getSentiment({ content: '' })).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('shold throw InternalServerErrorException with error', async () => {
+			jest.spyOn(global, 'fetch').mockResolvedValue({
+				json: async () => {
+					return { error: 'error' };
+				},
+			} as any);
+
+			await expect(service.getSentiment({ content: 'test' })).rejects.toThrow(
+				'sentiment api failed',
+			);
+
+			await expect(service.getSentiment({ content: 'test' })).rejects.toThrow(
+				InternalServerErrorException,
+			);
+		});
+
+		it('should throw InternalServerErrorException with no positive, negative, or neutral', async () => {
+			jest.spyOn(global, 'fetch').mockResolvedValue({
+				json: async () => {
+					return { document: { confidence: {} } };
+				},
+			} as any);
+
+			await expect(service.getSentiment({ content: 'test' })).rejects.toThrow(
+				'sentiment api failed',
+			);
+
+			await expect(service.getSentiment({ content: 'test' })).rejects.toThrow(
+				InternalServerErrorException,
+			);
+		});
+
+		it('should return sentiment', async () => {
+			const sentiment = await service.getSentiment({ content: 'test' });
+			expect(sentiment).toBeDefined();
+		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
 	});
 });


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

- 코드 커버리지를 100%로 만들기 위해 모든 에러처리를 통과하는 유닛 테스트 코드를 작성함

### 🎇 동작 화면

#### galaxy

<img width="1017" alt="스크린샷 2023-12-08 오전 1 00 44" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/a4dc1a89-8afd-4950-b9e5-7b4272452e53">

<img width="649" alt="스크린샷 2023-12-08 오전 1 02 02" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/b9df297a-0a0c-4175-9ad0-402dcdb1af07">

#### sentiment

<img width="683" alt="스크린샷 2023-12-08 오전 1 37 32" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/5efd7796-742f-4a52-9c9b-8d6072d2ace5">

<img width="638" alt="스크린샷 2023-12-08 오전 1 26 59" src="https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/67c4c27f-ed7a-4e9d-afd6-38271a0b32f6">


### 💫 기타사항
