### PR TITLE
[HotFix] sharelink API nickname 리턴하도록 수정

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -294,6 +294,6 @@ export class AuthService {
 			throw new InternalServerErrorException('link user not found');
 		}
 
-		return linkUser.username;
+		return linkUser.nickname;
 	}
 }


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- ShareLink에 대하여 nickname이 아닌 username 반환하던 오류 수정

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항
