### PR TITLE
[BE] auth 모듈 e2e테스트 작성

### DIFF
--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -8,7 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { jwtConfig } from '../config/jwt.config';
 import { RedisRepository } from './redis.repository';
 import { CookieAuthGuard } from './cookie-auth.guard';
-import { ShareLink } from './entities/share_link.entity';
+import { ShareLink } from './entities/share-link.entity';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Galaxy, GalaxySchema } from '../galaxy/schemas/galaxy.schema';
 import {

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -24,7 +24,7 @@ import {
 } from '../util/auth.util';
 import { v4 as uuid } from 'uuid';
 import { UserDataDto } from './dto/user-data.dto';
-import { ShareLink } from './entities/share_link.entity';
+import { ShareLink } from './entities/share-link.entity';
 import { InjectModel } from '@nestjs/mongoose';
 import { Galaxy } from '../galaxy/schemas/galaxy.schema';
 import { Model } from 'mongoose';
@@ -253,33 +253,33 @@ export class AuthService {
 			throw new BadRequestException('nickname is required');
 		}
 
-		const user = await this.userRepository.findOneBy({ nickname });
+		const user: User = await this.userRepository.findOneBy({ nickname });
 
 		if (!user) {
 			throw new NotFoundException('user not found');
 		}
 
-		const foundLink = await this.shareLinkRepository.findOneBy({
-			user: user.id,
+		const shareLink = await this.shareLinkRepository.findOneBy({
+			user: { id: user.id },
 		});
 
-		if (foundLink) {
-			return foundLink;
+		if (shareLink) {
+			return shareLink.link;
 		}
 
-		const newLink = this.shareLinkRepository.create({
-			user: user.id,
+		const newShareLink = this.shareLinkRepository.create({
 			link: uuid(),
+			user: user,
 		});
 
-		const savedLink = await this.shareLinkRepository.save(newLink);
-		savedLink.user = undefined;
-		return savedLink;
+		const savedShareLink = await this.shareLinkRepository.save(newShareLink);
+		return savedShareLink.link;
 	}
 
 	async getUsernameByShareLink(shareLink: string) {
-		const foundLink = await this.shareLinkRepository.findOneBy({
-			link: shareLink,
+		const foundLink = await this.shareLinkRepository.findOne({
+			where: { link: shareLink },
+			relations: ['user'],
 		});
 
 		if (!foundLink) {
@@ -287,7 +287,7 @@ export class AuthService {
 		}
 
 		const linkUser = await this.userRepository.findOneBy({
-			id: foundLink.user,
+			id: foundLink.user.id,
 		});
 
 		if (!linkUser) {

--- a/packages/server/src/auth/entities/share-link.entity.ts
+++ b/packages/server/src/auth/entities/share-link.entity.ts
@@ -15,10 +15,10 @@ export class ShareLink {
 	@Column({ type: 'varchar', length: 200, nullable: false, unique: true })
 	link: string;
 
-	@OneToOne(() => User, (user) => user.id, {
+	@OneToOne(() => User, (user) => user.shareLink, {
 		eager: false,
 		onDelete: 'CASCADE',
 	})
 	@JoinColumn()
-	user: number;
+	user: User;
 }

--- a/packages/server/src/auth/entities/user.entity.ts
+++ b/packages/server/src/auth/entities/user.entity.ts
@@ -8,7 +8,7 @@ import {
 	OneToOne,
 	PrimaryGeneratedColumn,
 } from 'typeorm';
-import { ShareLink } from './share_link.entity';
+import { ShareLink } from './share-link.entity';
 import { UserShareStatus } from '../enums/user.enum';
 
 @Entity()

--- a/packages/server/test/auth/auth.e2e-spec.ts
+++ b/packages/server/test/auth/auth.e2e-spec.ts
@@ -278,7 +278,29 @@ describe('AuthController (/auth, e2e)', () => {
 			.expect(400);
 	});
 
-	it.todo('GET /auth/sharelink');
+	it('GET /auth/sharelink', async () => {
+		const randomeBytes = Math.random().toString(36).slice(2, 10);
 
-	it.todo('GET /auth/sharelink/:sharelink');
+		const newUser = {
+			username: randomeBytes,
+			nickname: randomeBytes,
+			password: randomeBytes,
+		};
+
+		await request(app.getHttpServer()).post('/auth/signup').send(newUser);
+
+		const response = await request(app.getHttpServer())
+			.get(`/auth/sharelink?nickname=${randomeBytes}`)
+			.expect(200);
+
+		expect(response).toHaveProperty('text');
+		const sharelink = response.text;
+
+		const sharelinkResponse = await request(app.getHttpServer())
+			.get(`/auth/sharelink/${sharelink}`)
+			.expect(200);
+
+		const nickname = sharelinkResponse.text;
+		expect(nickname).toBe(randomeBytes);
+	});
 });

--- a/packages/server/test/auth/auth.e2e-spec.ts
+++ b/packages/server/test/auth/auth.e2e-spec.ts
@@ -188,4 +188,12 @@ describe('AuthController (/auth, e2e)', () => {
 			'accessToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None',
 		);
 	});
+
+	it.todo('GET /auth/search');
+
+	it.todo('PATCH /auth/status');
+
+	it.todo('GET /auth/sharelink');
+
+	it.todo('GET /auth/sharelink/:sharelink');
 });

--- a/packages/server/test/board/board.e2e-spec.ts
+++ b/packages/server/test/board/board.e2e-spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../src/app.module';
-import { Board } from '../../src/board/entities/board.entity';
 import { UpdateBoardDto } from '../../src/board/dto/update-board.dto';
 import { CreateBoardDto } from '../../src/board/dto/create-board.dto';
 import * as cookieParser from 'cookie-parser';


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

search, status 수정, sharelink 관련 테스트 코드 작성

공유링크 관련 eager 옵션으로 인한 버그 수정

### 🫨 고민한 부분

entity끼리 관계를 만들때 eager 옵션을 false로 두면 find할 때 자동으로 찾아오지 않음

```tsx
// user.entity.ts
import ...

@Entity()
@Index('IDX_FULLTEXT_NICKNAME', ['nickname'], { fulltext: true })
export class User {

	...

	@OneToOne(() => ShareLink, (shareLink) => shareLink.user, {
		eager: false,  // eager false
		onDelete: 'SET NULL',
	})
	shareLink: ShareLink;

	...

}
```

```tsx
// share-link.entity.ts
import ...

@Entity()
export class ShareLink {

	...

	@OneToOne(() => User, (user) => user.shareLink, {
		eager: false,  // eager false
		onDelete: 'CASCADE',
	})
	@JoinColumn()
	user: User;
}
```

이러고 `sharelinkRepository.find()`로 링크 정보를 조회하면 다음과 같이 유저 정보는 함께 반환되지 않음
이러한 문제로 유저 정보를 같이 가져오지 못해서 유저의 닉네임도 조회하지 못하는 문제가 발생했음
근데 이 과정에서 shareLinkRepository에서 findOneBy를 사용하였는데, 옵션에 user정보에 undefined를 사용해도 그냥 맨 처음 저장된 링크 정보를 가져와서 이게 잘못된지 몰랐던 것 -> 옵션이 아예 없다고 판단해서 다 조회하고 그 중 첫 번째(findOne) 정보를 가져온듯..
아무튼 이러한 문제를 아래 과정으로 해결함

![1](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/66247e47-adf0-4e80-a57c-4d540c0d7122)

해결법은 일단 eager를 true로 두는 방법이 있음

이렇게 하면 조회하면 무조건 user정보를 가져옴

![2](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/4019ae57-4b34-4b5f-9a1a-01c4e07ea81e)


그러나 만약 항상 가져오지는 않고 필요할 때만 가져오고 싶다(이게 원래 eager 옵션의 목적)

eager옵션을 false로 하고 이렇게 하면 됨

```tsx
shareLinkRepository.find({
	relations: ['user'],  // 엔티티의 변수명 입력
});
	
```
![3](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/7fc8de5c-5bf2-461f-9839-1ca36302ce55)


### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항
