### PR TITLE
[FE] 하단바 디자인 수정

### DIFF
--- a/packages/client/src/entities/posts/ui/Posts.tsx
+++ b/packages/client/src/entities/posts/ui/Posts.tsx
@@ -11,6 +11,8 @@ export default function Posts() {
 	const { page, nickName } = useCheckNickName();
 
 	useEffect(() => {
+		if (!page) return;
+
 		if (page === 'home') {
 			(async () => {
 				const myPostData = await getMyPost();
@@ -19,12 +21,10 @@ export default function Posts() {
 			return;
 		}
 
-		if (page === 'search' || page === 'share') {
-			(async () => {
-				const otherPostData = await getPostListByNickName(nickName);
-				setPostData(otherPostData);
-			})();
-		}
+		(async () => {
+			const otherPostData = await getPostListByNickName(nickName);
+			setPostData(otherPostData);
+		})();
 	}, [page, nickName]);
 
 	return (

--- a/packages/client/src/entities/posts/ui/Posts.tsx
+++ b/packages/client/src/entities/posts/ui/Posts.tsx
@@ -19,10 +19,12 @@ export default function Posts() {
 			return;
 		}
 
-		(async () => {
-			const otherPostData = await getPostListByNickName(nickName);
-			setPostData(otherPostData);
-		})();
+		if (page === 'search' || page === 'share') {
+			(async () => {
+				const otherPostData = await getPostListByNickName(nickName);
+				setPostData(otherPostData);
+			})();
+		}
 	}, [page, nickName]);
 
 	return (

--- a/packages/client/src/shared/lib/constants/width.ts
+++ b/packages/client/src/shared/lib/constants/width.ts
@@ -1,2 +1,2 @@
 export const MAX_WIDTH1 = 1210;
-export const MAX_WIDTH2 = 930;
+export const MAX_WIDTH2 = 810;

--- a/packages/client/src/shared/routes/PrivateRoute.tsx
+++ b/packages/client/src/shared/routes/PrivateRoute.tsx
@@ -11,9 +11,9 @@ export default function PrivateRoute() {
 			try {
 				await getSignInInfo();
 				setIsAuthenticated(true);
-				setIsLoading(false);
 			} catch (error) {
 				setIsAuthenticated(false);
+			} finally {
 				setIsLoading(false);
 			}
 		})();

--- a/packages/client/src/shared/routes/PublicRoute.tsx
+++ b/packages/client/src/shared/routes/PublicRoute.tsx
@@ -11,9 +11,9 @@ export default function PublicRoute() {
 			try {
 				await getSignInInfo();
 				setIsAuthenticated(true);
-				setIsLoading(false);
 			} catch (error) {
 				setIsAuthenticated(false);
+			} finally {
 				setIsLoading(false);
 			}
 		})();

--- a/packages/client/src/widgets/underBar/UnderBar.tsx
+++ b/packages/client/src/widgets/underBar/UnderBar.tsx
@@ -2,11 +2,7 @@ import styled from '@emotion/styled';
 import { Button } from 'shared/ui';
 import { Title01 } from '../../shared/ui/styles';
 import PlanetEditIcon from '@icons/icon-planetedit-24-white.svg';
-import PlanetEditIconGray from '@icons/icon-planetedit-24-gray.svg';
-import AddIcon from '@icons/icon-add-24-white.svg';
-import AddIconGray from '@icons/icon-add-24-gray.svg';
 import WriteIcon from '@icons/icon-writte-24-white.svg';
-import WriteIconGray from '@icons/icon-writte-24-gray.svg';
 import { BASE_URL, MAX_WIDTH1, MAX_WIDTH2 } from 'shared/lib/constants';
 import { useNavigate } from 'react-router-dom';
 import Cookies from 'js-cookie';
@@ -72,30 +68,27 @@ export default function UnderBar() {
 					<Button
 						size="m"
 						buttonType="Button"
-						disabled={!isMyPage}
 						onClick={handleShareButton}
+						style={{ display: isMyPage ? 'flex' : 'none' }}
 					>
 						공유하기
 					</Button>
 				</SmallButtonsContainer>
 
-				<Line />
+				<Line style={{ display: isMyPage ? 'flex' : 'none' }} />
 
 				<BigButtonsContainer>
 					<BigButton
 						size="l"
 						buttonType="Button"
 						onClick={handleGalaxyCustomButton}
-						disabled={!isMyPage}
+						style={{ display: isMyPage ? 'flex' : 'none' }}
 					>
-						<img
-							src={isMyPage ? PlanetEditIcon : PlanetEditIconGray}
-							alt="은하 수정하기"
-						/>
+						<img src={PlanetEditIcon} alt="은하 수정하기" />
 						은하 수정하기
 					</BigButton>
 
-					<BigButton
+					{/* <BigButton
 						size="l"
 						buttonType="Button"
 						disabled={!isMyPage}
@@ -103,15 +96,15 @@ export default function UnderBar() {
 					>
 						<img src={isMyPage ? AddIcon : AddIconGray} alt="별 스킨 만들기" />
 						별 스킨 만들기
-					</BigButton>
+					</BigButton> */}
 
 					<BigButton
 						size="l"
 						buttonType="CTA-icon"
-						disabled={!isMyPage}
 						onClick={handleWritingButton}
+						style={{ display: isMyPage ? 'flex' : 'none' }}
 					>
-						<img src={isMyPage ? WriteIcon : WriteIconGray} alt="글쓰기" />
+						<img src={WriteIcon} alt="글쓰기" />
 						글쓰기
 					</BigButton>
 				</BigButtonsContainer>
@@ -153,7 +146,9 @@ const ButtonsContainer = styled.div`
 const SmallButtonsContainer = styled.div`
 	display: flex;
 	flex-direction: column;
+	justify-content: center;
 	gap: 4px;
+	height: 76px;
 `;
 
 const BigButtonsContainer = styled.div`

--- a/packages/client/src/widgets/underBar/UnderBar.tsx
+++ b/packages/client/src/widgets/underBar/UnderBar.tsx
@@ -135,7 +135,7 @@ const Layout = styled.div`
 	}
 
 	@media (max-width: ${MAX_WIDTH2}px) {
-		width: 900px;
+		width: ${MAX_WIDTH2 - 30}px;
 	}
 `;
 


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 별 스킨 만들기 버튼을 삭제했습니다.
  - 동민님 코드랑 꼬일 것 같아서 코드 주석처리 해두었습니다.
- 남의 은하에 갔을 때 기존에는 버튼이 비활성화되었었는데, 아예 보이지 않도록 수정했습니다.   
  - 남의 은하에 가면 로그아웃 버튼만 보입니다.
- 반응형 width값을 변경했습니다.
  - 버튼이 하나 없어져서, 하단바가 최대로 줄어들 수 있는 width값을 수정했습니다 . 
- Posts.tsx에서 api 호출하는 부분 수정
    ```js
   if (!page) return; // 추가된 코드
   
    if (page === 'home') {
      내 우주일 때 api 통신 코드 
      return;
    }
    
    남의 우주일 때 api 통신 코드 
    ```

### 🫨 고민한 부분
- Posts.tsx에서, page가 home임에도 불구하고 자꾸 home이 아닐 때 호출되어야 하는 함수가 호출되었습니다.
- 그래서 star/by-author api가 계속 호출되어 에러가 나고 있었습니다.
- 알고보니 page 변수가 불러와지기 전 page가 빈 값일 때, '남의 우주일 때 api 통신 코드'가 먼저 실행되는 것이었습니다. 
    ```js
    if (page === 'home') {
      내 우주일 때 api 통신 코드 
      return;
    }
    
    남의 우주일 때 api 통신 코드 
    ```
- 그래서 가장 앞에 page가 falsy한 값이라면 리턴되게 처리해주었습니다.

### 📌 중점적으로 볼 부분
- Underbar.tsx

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/c200e5aa-6190-4911-8f63-e19bdf3ad9f5

### 💫 기타사항
