### PR TITLE
[BE] Auth Controller 유닛 테스트 작성, checkNickname Api 구현

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -46,6 +46,7 @@ import { CheckSignInSwaggerDecorator } from './decorators/swagger/check-sign-in-
 import { cookieOptionsConfig } from '../config/cookie.config';
 import { GetUsernameByShareLinkSwaggerDecorator } from './decorators/swagger/get-username-by-sharelink.decorator';
 import { HttpExceptionFilter } from '../exception-filter/http.exception-filter';
+import { CheckNicknameSwaggerDecorator } from './decorators/swagger/check-nickname-swagger.decorator';
 
 @Controller('auth')
 @UseInterceptors(LogInterceptor)
@@ -89,6 +90,12 @@ export class AuthController {
 	async checkSignIn(@GetUser() userData: UserDataDto) {
 		const user = await this.authService.findUserById(userData.userId);
 		return user;
+	}
+
+	@Get('check-nickname')
+	@CheckNicknameSwaggerDecorator()
+	async checkNickname(@Query('nickname') nickname: string) {
+		return this.authService.checkNickname(nickname);
 	}
 
 	@Get('signout')

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -297,12 +297,12 @@ export class AuthService {
 		return linkUser.nickname;
 	}
 
-	checkNickname(nickname: string) {
+	async checkNickname(nickname: string) {
 		if (!nickname) {
 			throw new BadRequestException('nickname is required');
 		}
 
-		const user = this.userRepository.findOneBy({ nickname });
+		const user = await this.userRepository.findOneBy({ nickname });
 
 		if (!user) {
 			throw new NotFoundException('user not found');

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -296,4 +296,18 @@ export class AuthService {
 
 		return linkUser.nickname;
 	}
+
+	checkNickname(nickname: string) {
+		if (!nickname) {
+			throw new BadRequestException('nickname is required');
+		}
+
+		const user = this.userRepository.findOneBy({ nickname });
+
+		if (!user) {
+			throw new NotFoundException('user not found');
+		}
+
+		return true;
+	}
 }

--- a/packages/server/src/auth/decorators/swagger/check-nickname-swagger.decorator.ts
+++ b/packages/server/src/auth/decorators/swagger/check-nickname-swagger.decorator.ts
@@ -1,0 +1,38 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+	ApiBadRequestResponse,
+	ApiNotFoundResponse,
+	ApiOkResponse,
+	ApiOperation,
+} from '@nestjs/swagger';
+
+const apiOperation = {
+	summary: '닉네임을 가진 유저 확인',
+	description:
+		'닉네임을 가진 유저가 있으면 true\n' +
+		'닉네임을 가진 유저가 없으면 NotFoundError를 반환합니다.',
+};
+
+const apiOkResponse = {
+	status: 200,
+	description: '닉네임을 가진 유저가 있어 true를 반환',
+};
+
+const apiBadRequestResponse = {
+	status: 400,
+	description: '쿼리스트링에 닉네임이 없어 BadRequestError를 반환',
+};
+
+const apiNotFoundResponse = {
+	status: 404,
+	description: '닉네임을 가진 유저가 없음',
+};
+
+export const CheckNicknameSwaggerDecorator = () => {
+	return applyDecorators(
+		ApiOperation(apiOperation),
+		ApiOkResponse(apiOkResponse),
+		ApiBadRequestResponse(apiBadRequestResponse),
+		ApiNotFoundResponse(apiNotFoundResponse),
+	);
+};

--- a/packages/server/test/auth/auth.controller.spec.ts
+++ b/packages/server/test/auth/auth.controller.spec.ts
@@ -10,6 +10,7 @@ import { Galaxy } from '../../src/galaxy/schemas/galaxy.schema';
 import { Model } from 'mongoose';
 import { getModelToken } from '@nestjs/mongoose';
 import { RedisRepository } from '../../src/auth/redis.repository';
+import { UserDataDto } from '../../src/auth/dto/user-data.dto';
 
 describe('AuthController', () => {
 	let controller: AuthController;
@@ -49,7 +50,7 @@ describe('AuthController', () => {
 		expect(controller).toBeDefined();
 	});
 
-	it('POST /auth/signup', async () => {
+	it('signUp', async () => {
 		expect(controller.signUp).toBeDefined();
 
 		jest.spyOn(service, 'signUp').mockImplementation(async () => {
@@ -72,5 +73,250 @@ describe('AuthController', () => {
 		expect(result.username).toBe('test');
 		expect(result).toHaveProperty('nickname');
 		expect(result.nickname).toBe('test');
+	});
+
+	it('signIn', async () => {
+		expect(controller.signIn).toBeDefined();
+
+		const signInUserDto = {
+			username: 'test',
+			password: 'test',
+		};
+		jest.spyOn(service, 'signIn').mockImplementation(async (signInUserDto) => {
+			return { accessToken: 'token', refreshToken: 'token' };
+		});
+
+		const response = { cookie: jest.fn() } as any; // res의 cookie 메서드를 mock으로 만들어줌
+		const result = await controller.signIn(signInUserDto, response);
+		expect(result).toBeDefined();
+		expect(result).toHaveProperty('accessToken');
+		expect(result).toHaveProperty('refreshToken');
+		expect(result.accessToken).toBe('token');
+		expect(result.refreshToken).toBe('token');
+		// response의 cookie 메소드의 호출 테스트
+		expect(response.cookie.mock.calls[0][0]).toBe('accessToken'); // 첫 번째 호출의 첫 번째 인자가 'accessToken'인지 확인
+		expect(response.cookie.mock.calls[0][1]).toBe('token'); // 첫 번째 호출의 두 번째 인자가 'token'인지 확인
+		expect(response.cookie.mock.calls[0][2]).toBeDefined(); // 첫 번째 호출의 세 번째 인자가 정의되어 있는지 확인
+		expect(response.cookie.mock.calls[1][0]).toBe('refreshToken');
+		expect(response.cookie.mock.calls[1][1]).toBe('token');
+		expect(response.cookie.mock.calls[1][2]).toBeDefined();
+	});
+
+	it('checkSignIn', async () => {
+		expect(controller.checkSignIn).toBeDefined();
+		const userData = {
+			userId: 1,
+		} as UserDataDto;
+		jest
+			.spyOn(service, 'findUserById')
+			.mockImplementation(async (userId: number) => {
+				return {
+					id: userId,
+					username: 'test',
+					nickname: 'test',
+				} as User;
+			});
+
+		const result = await controller.checkSignIn(userData);
+		expect(result).toBeDefined();
+		expect(result).toHaveProperty('id');
+		expect(result).toHaveProperty('username');
+		expect(result.username).toBe('test');
+		expect(result).toHaveProperty('nickname');
+		expect(result.nickname).toBe('test');
+	});
+
+	it('signOut', async () => {
+		expect(controller.signOut).toBeDefined();
+		const userData = {
+			username: 'test',
+		} as UserDataDto;
+		jest.spyOn(service, 'signOut').mockImplementation(async (userData) => {
+			return;
+		});
+
+		const response = { clearCookie: jest.fn() } as any; // res의 clearCookie 메서드를 mock으로 만들어줌
+		const result = await controller.signOut(response, userData);
+		expect(result).toBeDefined();
+		expect(response.clearCookie.mock.calls[0][0]).toBe('accessToken');
+		expect(response.clearCookie.mock.calls[0][1]).toBeDefined();
+		expect(response.clearCookie.mock.calls[1][0]).toBe('refreshToken');
+		expect(response.clearCookie.mock.calls[1][1]).toBeDefined();
+	});
+
+	it('isAvailableUsername', async () => {
+		expect(controller.isAvailableUsername).toBeDefined();
+		jest
+			.spyOn(service, 'isAvailableUsername')
+			.mockImplementation(async (username: string) => {
+				return true;
+			});
+
+		const result = await controller.isAvailableUsername('test');
+		expect(result).toBeDefined();
+		expect(result).toBe(true);
+	});
+
+	it('isAvailableNickname', async () => {
+		expect(controller.isAvailableNickname).toBeDefined();
+		jest
+			.spyOn(service, 'isAvailableNickname')
+			.mockImplementation(async (nickname: string) => {
+				return true;
+			});
+
+		const result = await controller.isAvailableNickname('test');
+		expect(result).toBeDefined();
+		expect(result).toBe(true);
+	});
+
+	it('signInWithOAuth', async () => {
+		expect(controller.signInWithOAuth).toBeDefined();
+
+		const gitHubSignInResponse = { redirect: jest.fn() } as any;
+		await controller.signInWithOAuth('github', gitHubSignInResponse);
+		expect(gitHubSignInResponse.redirect.mock.calls[0][0]).toBe(
+			`https://github.com/login/oauth/authorize?client_id=${process.env.OAUTH_GITHUB_CLIENT_ID}&scope=read:user%20user:email`,
+		);
+
+		const naverSignInResponse = { redirect: jest.fn() } as any;
+		await controller.signInWithOAuth('naver', naverSignInResponse);
+		expect(naverSignInResponse.redirect.mock.calls[0][0]).toBe(
+			`https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.OAUTH_NAVER_CLIENT_ID}&redirect_uri=${process.env.OAUTH_NAVER_REDIRECT_URI}&state=STATE_STRING`,
+		);
+
+		const googleSignInResponse = { redirect: jest.fn() } as any;
+		await controller.signInWithOAuth('google', googleSignInResponse);
+		expect(googleSignInResponse.redirect.mock.calls[0][0]).toBe(
+			`https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.OAUTH_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.OAUTH_GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile`,
+		);
+	});
+
+	it('oauthCallback - FirstSignIN', async () => {
+		expect(controller.oauthCallback).toBeDefined();
+
+		jest
+			.spyOn(service, 'oauthCallback')
+			.mockImplementation(
+				async (service: string, code: string, state: string) => {
+					return {
+						username: 'test',
+						accessToken: null,
+						refreshToken: null,
+					};
+				},
+			);
+
+		const response = { cookie: jest.fn(), redirect: jest.fn() } as any;
+		await controller.oauthCallback('testService', 'code', 'state', response);
+
+		expect(response.cookie.mock.calls[0][0]).toBe('testServiceUsername');
+		expect(response.cookie.mock.calls[0][1]).toBe('test');
+		expect(response.cookie.mock.calls[0][2]).toBeDefined();
+		expect(response.redirect.mock.calls[0][0]).toBe('/nickname/testService');
+	});
+
+	it('oauthCallback - NotFirstSignIN', async () => {
+		expect(controller.oauthCallback).toBeDefined();
+
+		jest
+			.spyOn(service, 'oauthCallback')
+			.mockImplementation(
+				async (service: string, code: string, state: string) => {
+					return {
+						username: null,
+						accessToken: 'token',
+						refreshToken: 'token',
+					};
+				},
+			);
+
+		const response = { cookie: jest.fn(), redirect: jest.fn() } as any;
+		await controller.oauthCallback('testService', 'code', 'state', response);
+
+		expect(response.cookie.mock.calls[0][0]).toBe('accessToken');
+		expect(response.cookie.mock.calls[0][1]).toBe('token');
+		expect(response.cookie.mock.calls[0][2]).toBeDefined();
+		expect(response.cookie.mock.calls[1][0]).toBe('refreshToken');
+		expect(response.cookie.mock.calls[1][1]).toBe('token');
+		expect(response.cookie.mock.calls[1][2]).toBeDefined();
+		expect(response.redirect.mock.calls[0][0]).toBe('/login');
+	});
+
+	it('oauthSignUp', async () => {
+		expect(controller.signUpWithOAuth).toBeDefined();
+
+		jest
+			.spyOn(service, 'signUpWithOAuth')
+			.mockImplementation(
+				async (
+					service: string,
+					nickname: string,
+					resourceServerUsername: string,
+				) => {
+					return {} as User;
+				},
+			);
+
+		const response = { clearCookie: jest.fn(), redirect: jest.fn() } as any;
+		await controller.signUpWithOAuth(
+			'testService',
+			'test',
+			{ cookies: { testServiceUsername: 'test' } },
+			response,
+		);
+		expect(response.clearCookie.mock.calls[0][0]).toBe('testServiceUsername');
+		expect(response.clearCookie.mock.calls[0][1]).toBeDefined();
+		expect(response.redirect.mock.calls[0][0]).toBe('/login');
+	});
+
+	it('searchUser', async () => {
+		expect(controller.searchUser).toBeDefined();
+
+		jest
+			.spyOn(service, 'searchUser')
+			.mockImplementation(async (nickname: string) => {
+				return [
+					{ id: 1, nickname: 'test1' },
+					{ id: 2, nickname: 'test2' },
+				] as User[];
+			});
+
+		const result = await controller.searchUser('test');
+		expect(result).toBeDefined();
+		expect(result[0]).toHaveProperty('id');
+		expect(result[0]).toHaveProperty('nickname');
+		expect(result[0].nickname).toBe('test1');
+		expect(result[1]).toHaveProperty('id');
+		expect(result[1]).toHaveProperty('nickname');
+		expect(result[1].nickname).toBe('test2');
+	});
+
+	it('getShareLinkByNickname', async () => {
+		expect(controller.getShareLinkByNickname).toBeDefined();
+
+		jest
+			.spyOn(service, 'getShareLinkByNickname')
+			.mockImplementation(async (nickname: string) => {
+				return 'test';
+			});
+
+		const result = await controller.getShareLinkByNickname('test');
+		expect(result).toBeDefined();
+		expect(result).toBe('test');
+	});
+
+	it('getUsernameByShareLink', async () => {
+		expect(controller.getUsernameByShareLink).toBeDefined();
+
+		jest
+			.spyOn(service, 'getUsernameByShareLink')
+			.mockImplementation(async (shareLink: string) => {
+				return 'test';
+			});
+
+		const result = await controller.getUsernameByShareLink('test');
+		expect(result).toBeDefined();
+		expect(result).toBe('test');
 	});
 });

--- a/packages/server/test/auth/auth.controller.spec.ts
+++ b/packages/server/test/auth/auth.controller.spec.ts
@@ -1,6 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from '../../src/auth/auth.controller';
 import { AuthService } from '../../src/auth/auth.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../src/auth/entities/user.entity';
+import { ShareLink } from '../../src/auth/entities/share-link.entity';
+import { JwtService } from '@nestjs/jwt';
+import { Galaxy } from '../../src/galaxy/schemas/galaxy.schema';
+import { Model } from 'mongoose';
+import { getModelToken } from '@nestjs/mongoose';
+import { RedisRepository } from '../../src/auth/redis.repository';
 
 describe('AuthController', () => {
 	let controller: AuthController;
@@ -8,7 +17,27 @@ describe('AuthController', () => {
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [AuthController],
-			providers: [AuthService],
+			providers: [
+				AuthService,
+				{
+					provide: getRepositoryToken(User),
+					useClass: Repository,
+				},
+				{
+					provide: getRepositoryToken(ShareLink),
+					useClass: Repository,
+				},
+				RedisRepository,
+				JwtService,
+				{
+					provide: getModelToken(Galaxy.name),
+					useValue: Model,
+				},
+				{
+					provide: getModelToken('Exception'),
+					useValue: Model,
+				},
+			],
 		}).compile();
 
 		controller = module.get<AuthController>(AuthController);

--- a/packages/server/test/auth/auth.controller.spec.ts
+++ b/packages/server/test/auth/auth.controller.spec.ts
@@ -13,6 +13,7 @@ import { RedisRepository } from '../../src/auth/redis.repository';
 
 describe('AuthController', () => {
 	let controller: AuthController;
+	let service: AuthService;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -41,9 +42,35 @@ describe('AuthController', () => {
 		}).compile();
 
 		controller = module.get<AuthController>(AuthController);
+		service = module.get<AuthService>(AuthService);
 	});
 
 	it('should be defined', () => {
 		expect(controller).toBeDefined();
+	});
+
+	it('POST /auth/signup', async () => {
+		expect(controller.signUp).toBeDefined();
+
+		jest.spyOn(service, 'signUp').mockImplementation(async () => {
+			return {
+				id: 1,
+				username: 'test',
+				nickname: 'test',
+			};
+		});
+
+		const result = await controller.signUp({
+			username: 'test',
+			nickname: 'test',
+			password: 'test',
+		});
+
+		expect(result).toBeDefined();
+		expect(result).toHaveProperty('id');
+		expect(result).toHaveProperty('username');
+		expect(result.username).toBe('test');
+		expect(result).toHaveProperty('nickname');
+		expect(result.nickname).toBe('test');
 	});
 });

--- a/packages/server/test/auth/auth.controller.spec.ts
+++ b/packages/server/test/auth/auth.controller.spec.ts
@@ -126,6 +126,19 @@ describe('AuthController', () => {
 		expect(result.nickname).toBe('test');
 	});
 
+	it('checkNickname', async () => {
+		expect(controller.checkNickname).toBeDefined();
+		jest
+			.spyOn(service, 'checkNickname')
+			.mockImplementation(async (nickname: string) => {
+				return true;
+			});
+
+		const result = await controller.checkNickname('test');
+		expect(result).toBeDefined();
+		expect(result).toBe(true);
+	});
+
 	it('signOut', async () => {
 		expect(controller.signOut).toBeDefined();
 		const userData = {


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

AuthController 유닛 테스트 작성

닉네임을 쿼리스트링으로 받아 닉네임을 가진 회원이 있으면 true, 없으면 404를 발생시키는 API 구현

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

필요한 함수를 jest.fn()으로 만들고 함수.mock.calls를 하면 아래와 같이 확인할 수 있네요 !
@Res로 리스폰스를 가져와서 쿠키 처리하는 부분 어떻게 테스트해야 하나 했는데 아래처럼 해결했습니다.
```
const response = { cookie: jest.fn() } as any; // res의 cookie 메서드를 mock으로 만들어줌
// response의 cookie 메소드의 호출 테스트
expect(response.cookie.mock.calls[0][0]).toBe('accessToken'); // 첫 번째 호출의 첫 번째 인자가 'accessToken'인지 확인
expect(response.cookie.mock.calls[0][1]).toBe('token'); // 첫 번째 호출의 두 번째 인자가 'token'인지 확인
expect(response.cookie.mock.calls[0][2]).toBeDefined(); // 첫 번째 호출의 세 번째 인자가 정의되어 있는지 확인
expect(response.cookie.mock.calls[1][0]).toBe('refreshToken');
expect(response.cookie.mock.calls[1][1]).toBe('token');
expect(response.cookie.mock.calls[1][2]).toBeDefined();
```

### 🎇 동작 화면

테스트 코드 통과
![스크린샷 2023-12-09 오후 11 02 21](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/190c057a-4d11-4abb-b2f9-e4efd8f7dd69)

AuthController 100퍼센트 커버
![스크린샷 2023-12-09 오후 11 12 50](https://github.com/boostcampwm2023/web16-B1G1/assets/101378867/60b91347-99a5-4e4a-a2e0-c7353556df78)


### 💫 기타사항

auth.module 이런 거는 신경 안써도 되겠죠?
auth.service까지 풀커버 해보겠습니다..