### PR TITLE
[BE] 어드민 페이지 계정인증 구현

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -5,6 +5,7 @@ import Board from './components/Board/Board.tsx';
 import Nav from './components/Nav.tsx';
 import SystemInfo from './components/SystemInfo/SystemInfo.tsx';
 import ExceptionStatistics from './components/ExceptionStatistics/ExceptionStatistics.tsx';
+import Login from './components/Login/Login.tsx';
 
 function App() {
 	return (
@@ -14,6 +15,7 @@ function App() {
 				<Link to={'/admin/board'}>Board</Link>
 				<Link to={'/admin/system-info'}>System Info</Link>
 				<Link to={'/admin/exception-statistics'}>Exception Statistics</Link>
+				<Link to={'/admin/login'}>Login</Link>
 			</Nav>
 			<Routes>
 				<Route path="/admin" element={<div>Home</div>} />
@@ -23,6 +25,7 @@ function App() {
 					path="/admin/exception-statistics"
 					element={<ExceptionStatistics />}
 				/>
+				<Route path="/admin/login" element={<Login />} />
 			</Routes>
 		</>
 	);

--- a/packages/admin/src/components/Board/Board.tsx
+++ b/packages/admin/src/components/Board/Board.tsx
@@ -10,6 +10,10 @@ export default function Board() {
 
 	const getBoardList = async () => {
 		const response = await fetch(baseUrl + '/admin/post');
+		if (response.status === 401) {
+			// 로그인 페이지로 리다이렉트
+			window.location.href = '/admin/login';
+		}
 		const data = await response.json();
 		setBoardList(data);
 	};
@@ -38,28 +42,27 @@ export default function Board() {
 					</tr>
 				</thead>
 				<tbody>
-					{boardList.map((board: any) => (
-						<tr key={board.id} id={board.id}>
-							<TD>{board.id}</TD>
-							<TD>{board.title}</TD>
-							<TD>{board.user.nickname}</TD>
-							<TD>{board.like_cnt}</TD>
-							<TD>{board.images.length}</TD>
-							<TD>{board.created_at}</TD>
-							<TD>{board.updated_at}</TD>
-							<TD>
-								<Button onClick={getBoardDetail}>상세 보기</Button>
-							</TD>
-						</tr>
-					))}
+					{boardList &&
+						boardList.map((board: any) => (
+							<tr key={board.id} id={board.id}>
+								<TD>{board.id}</TD>
+								<TD>{board.title}</TD>
+								<TD>{board.user.nickname}</TD>
+								<TD>{board.like_cnt}</TD>
+								<TD>{board.images.length}</TD>
+								<TD>{board.created_at}</TD>
+								<TD>{board.updated_at}</TD>
+								<TD>
+									<Button onClick={getBoardDetail}>상세 보기</Button>
+								</TD>
+							</tr>
+						))}
 				</tbody>
 			</Table>
 			<div>
 				{boardDetail &&
 					Object.keys(boardDetail)?.map((detail: any) => {
-						return (
-						  <div>{detail + ' | ' + boardDetail[detail]}</div>
-						);
+						return <div>{detail + ' | ' + boardDetail[detail]}</div>;
 					})}
 			</div>
 		</div>

--- a/packages/admin/src/components/ExceptionStatistics/ExceptionStatistics.tsx
+++ b/packages/admin/src/components/ExceptionStatistics/ExceptionStatistics.tsx
@@ -11,6 +11,10 @@ export default function ExceptionStatistics() {
 
 	const getAllExceptions = async () => {
 		const response = await fetch(baseUrl + '/admin/exception');
+		if (response.status === 401) {
+			// 로그인 페이지로 리다이렉트
+			window.location.href = '/admin/login';
+		}
 		const exceptions = await response.json();
 		exceptions.map((exception: Exception) => {
 			if (exception.path.includes('?')) {

--- a/packages/admin/src/components/Login/Login.tsx
+++ b/packages/admin/src/components/Login/Login.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+export default function Login() {
+	const [password, setPassword] = useState('');
+	const [loginResult, setLoginResult] = useState('');
+
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setPassword(e.target.value);
+	};
+
+	const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		const response = await fetch(baseUrl + '/admin/signin', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ password }),
+		});
+
+		if (response.ok) {
+			setLoginResult('로그인 성공');
+		} else {
+			setLoginResult('로그인 실패');
+		}
+	};
+
+	const handleLogout = async () => {
+		const response = await fetch(baseUrl + '/admin/signout');
+		if (response.ok) {
+			setLoginResult('로그아웃 되었습니다.');
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={handleLogin}>
+				<input type="password" value={password} onChange={handleChange} />
+				<button type="submit">로그인</button>
+			</form>
+			<span>{loginResult}</span>
+			<button onClick={handleLogout}>로그아웃</button>
+		</div>
+	);
+}

--- a/packages/admin/src/components/SystemInfo/SystemInfo.tsx
+++ b/packages/admin/src/components/SystemInfo/SystemInfo.tsx
@@ -9,6 +9,10 @@ export default function SystemInfo() {
 
 	const getSystemInfo = async () => {
 		const response = await fetch(baseUrl + '/admin/system-info');
+		if (response.status === 401) {
+			// 로그인 페이지로 리다이렉트
+			window.location.href = '/admin/login';
+		}
 		const data = await response.json();
 		setSystemInfo(data);
 	};
@@ -38,24 +42,22 @@ export default function SystemInfo() {
 				<thead>
 					<tr>
 						{systemInfo.diskUsageHead &&
-							systemInfo.diskUsageHead?.map(
-								(head: string, index: number) => <TH key={index}>{head}</TH>,
-							)}
+							systemInfo.diskUsageHead?.map((head: string, index: number) => (
+								<TH key={index}>{head}</TH>
+							))}
 					</tr>
 				</thead>
 				<tbody>
 					{systemInfo.diskUsage &&
-						systemInfo.diskUsage?.map(
-							(line: string[], index: number) => {
-								return (
-									<tr key={index}>
-										{line.map((item: string, index: number) => (
-											<TD key={index}>{item}</TD>
-										))}
-									</tr>
-								);
-							},
-						)}
+						systemInfo.diskUsage?.map((line: string[], index: number) => {
+							return (
+								<tr key={index}>
+									{line.map((item: string, index: number) => (
+										<TD key={index}>{item}</TD>
+									))}
+								</tr>
+							);
+						})}
 				</tbody>
 			</Table>
 		</div>

--- a/packages/server/src/admin/admin.controller.ts
+++ b/packages/server/src/admin/admin.controller.ts
@@ -1,22 +1,55 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpCode,
+	Post,
+	Res,
+	UseGuards,
+} from '@nestjs/common';
 import { AdminService } from './admin.service';
+import { AuthGuard } from '@nestjs/passport';
+import { Response } from 'express';
+import { cookieOptionsConfig } from 'src/config/cookie.config';
 
 @Controller('admin')
 export class AdminController {
 	constructor(private readonly adminService: AdminService) {}
 
 	@Get('post')
+	@UseGuards(AuthGuard())
 	getAllPosts() {
 		return this.adminService.getAllPosts();
 	}
 
 	@Get('system-info')
+	@UseGuards(AuthGuard())
 	getSystemInfo() {
 		return this.adminService.getSystemInfo();
 	}
 
 	@Get('exception')
+	@UseGuards(AuthGuard())
 	getAllExceptions() {
 		return this.adminService.getAllExceptions();
+	}
+
+	@Post('signin')
+	@HttpCode(200)
+	async signIn(
+		@Body('password') password: string,
+		@Res({ passthrough: true }) res: Response,
+	) {
+		const { adminAccessToken } = await this.adminService.signIn(password);
+		res.cookie('adminAccessToken', adminAccessToken, cookieOptionsConfig);
+
+		return { adminAccessToken };
+	}
+
+	@Get('signout')
+	async signOut(@Res({ passthrough: true }) res: Response) {
+		res.clearCookie('adminAccessToken', cookieOptionsConfig);
+
+		return { message: '어드민에서 로그아웃 되었습니다.' };
 	}
 }

--- a/packages/server/src/admin/admin.module.ts
+++ b/packages/server/src/admin/admin.module.ts
@@ -9,15 +9,21 @@ import {
 	Exception,
 	ExceptionSchema,
 } from '../exception-filter/exception.schema';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { jwtConfig } from 'src/config/jwt.config';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
 	imports: [
+		PassportModule.register({ defaultStrategy: 'jwt' }),
+		JwtModule.register(jwtConfig),
 		TypeOrmModule.forFeature([User, Board]),
 		MongooseModule.forFeature([
 			{ name: Exception.name, schema: ExceptionSchema },
 		]),
 	],
 	controllers: [AdminController],
-	providers: [AdminService],
+	providers: [AdminService, JwtStrategy],
 })
 export class AdminModule {}

--- a/packages/server/src/admin/admin.service.ts
+++ b/packages/server/src/admin/admin.service.ts
@@ -28,11 +28,6 @@ export class AdminService {
 	async getAllPosts() {
 		const posts = await this.boardRepository.find();
 
-		// // 컨텐츠 복호화
-		// posts.forEach((post) => {
-		// 	post.content = decryptAes(post.content);
-		// });
-
 		// 이미지 있는 경우 이미지 경로 추가
 		posts.forEach((post: any) => {
 			if (post.images.length <= 0) return;
@@ -40,8 +35,6 @@ export class AdminService {
 				(image) => `${awsConfig.endpoint.href}${bucketName}/${image.filename}`,
 			);
 		});
-
-		// console.log(posts);
 
 		return posts;
 	}

--- a/packages/server/src/admin/jwt.strategy.ts
+++ b/packages/server/src/admin/jwt.strategy.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { jwtConfig } from 'src/config/jwt.config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+	constructor() {
+		super({
+			secretOrKey: jwtConfig.secret,
+			jwtFromRequest: ExtractJwt.fromExtractors([
+				(req) => req.cookies?.adminAccessToken,
+			]),
+		});
+	}
+
+	async validate(payload: { admin: boolean }) {
+		return payload.admin;
+	}
+}


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- (BE) 어드민 모듈 signin, signout API 구현
- (FE) 어드민 로그인 페이지 구현, 비인가 접근시 리다이렉트

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

#### 백

https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/27fe0088-e265-42d0-9f88-b8cc6decc656

#### 프론트

https://github.com/boostcampwm2023/web16-B1G1/assets/138586629/475fb5d6-2b5a-4941-9c3b-20b4d52cafd0

### 💫 기타사항

