### PR TITLE
[HotFix] 사진 업로드 개수 제한 변경

### DIFF
--- a/packages/server/src/board/board.controller.ts
+++ b/packages/server/src/board/board.controller.ts
@@ -46,7 +46,7 @@ export class BoardController {
 
 	@Post()
 	@UseGuards(CookieAuthGuard)
-	@UseInterceptors(FilesInterceptor('file', 3))
+	@UseInterceptors(FilesInterceptor('file', 5))
 	@UsePipes(ValidationPipe)
 	@CreateBoardSwaggerDecorator()
 	async createBoard(
@@ -94,7 +94,7 @@ export class BoardController {
 	// 사진도 수정할 수 있도록 폼데이터 형태로 받기
 	@Patch(':id')
 	@UseGuards(CookieAuthGuard)
-	@UseInterceptors(FilesInterceptor('file', 3))
+	@UseInterceptors(FilesInterceptor('file', 5))
 	@UsePipes(ValidationPipe)
 	@UpdateBoardSwaggerDecorator()
 	async updateBoard(


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 사진 업로드 개수 제한 3에서 5로 변경

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항
