### PR TITLE
[FE] Galaxy, WarpScreen 색상 변경

### DIFF
--- a/packages/client/src/widgets/galaxy/lib/constants/index.ts
+++ b/packages/client/src/widgets/galaxy/lib/constants/index.ts
@@ -4,13 +4,13 @@ export const DISTANCE_LIMIT = 3000;
 
 export const starTypes = {
 	percentage: [
-		0.07, 0.1, 0.02, 0.14, 0.14, 0.07, 0.07, 0.02, 0.2, 0.2, 0.2, 0.2,
+		0.04, 0.03, 0.01, 0.04, 0.06, 0.06, 0.02, 0.01, 0.04, 0.06, 0.1, 0.1, 0.46,
 	],
 	color: [
 		0xffcece, 0xffe8ce, 0xceffe6, 0xcef9ff, 0xd2ceff, 0xff9d9d, 0xfffa9d,
-		0xb9ff9d, 0x9db9ff, 0xca9dff, 0x6445ff, 0x4570ff,
+		0xb9ff9d, 0x9db9ff, 0xca9dff, 0x6445ff, 0x4570ff, 0xffffff,
 	],
-	size: [0.5, 0.5, 0.3, 0.8, 0.3, 0.5, 0.5, 0.3, 1.3, 1.3, 1.1, 1.1],
+	size: [1, 0.5, 0.1, 0.8, 0.3, 0.5, 0.1, 0.1, 1.3, 1.3, 1.1, 1.1, 0.5],
 };
 
 export const ARMS_X_DIST = 5000;

--- a/packages/client/src/widgets/warpScreen/lib/constants.ts
+++ b/packages/client/src/widgets/warpScreen/lib/constants.ts
@@ -18,3 +18,13 @@ export const BLOOM_LUMINANCE_THRESHOLD = 0.55;
 export const BLOOM_LUMINANCE_SMOOTHING = 0;
 
 export const AMBIENT_LIGHT_INTENSITY = 15;
+
+export const SPACE_WARP_LINE_COLORS = [
+	'#627BFF',
+	'#3A5AFF',
+	'#6D3AFF',
+	'#9734FF',
+	'#EFE0FF',
+	'#DDDDDD',
+	'#FDFFE2',
+];

--- a/packages/client/src/widgets/warpScreen/ui/SpaceWarp.tsx
+++ b/packages/client/src/widgets/warpScreen/ui/SpaceWarp.tsx
@@ -4,13 +4,13 @@ import { useMemo } from 'react';
 import * as THREE from 'three';
 import {
 	SPACE_WARP_LINES_NUM,
+	SPACE_WARP_LINE_COLORS,
 	SPACE_WARP_LINE_LENGTH,
 	SPACE_WARP_XZ_MAX,
 	SPACE_WARP_XZ_MIN,
 	SPACE_WARP_Y_MAX,
 	SPACE_WARP_Y_MIN,
 } from '../lib/constants';
-import { BACKGROUND_STAR_COLORS } from 'features/backgroundStars/lib/constants';
 import React from 'react';
 
 const geSpaceWarpLinesInfo = () => {
@@ -24,7 +24,7 @@ const geSpaceWarpLinesInfo = () => {
 
 	const colors = Array.from({ length: SPACE_WARP_LINES_NUM }, () => {
 		const color = new THREE.Color(
-			BACKGROUND_STAR_COLORS[getRandomInt(0, BACKGROUND_STAR_COLORS.length)],
+			SPACE_WARP_LINE_COLORS[getRandomInt(0, SPACE_WARP_LINE_COLORS.length)],
 		);
 
 		return [color.r, color.g, color.b];


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- Galaxy 별 색을 변경했습니다.
  - 최적화 한 후에 색이 너무 진해진 것 같아서 더 연하게 하려 했으나... 그냥.. 네 뭐 결과적으로는 별 차이가 없는 것 같기도 하네요
- Space Warp 라인 색을 변경했습니다.
  - 기존에는 알록달록한 느낌이었는데 저희 UI 컨셉에 맞추어 보랏빛으로 변경했습니다.  

### 🫨 고민한 부분
- 무슨 색을 할 지...

### 📌 중점적으로 볼 부분
- 그냥 색만 봐주시면 될 것 같네요

### 🎇 동작 화면
![image](https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/146405fd-a44d-40bd-8a94-c96912f85fe7)

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/c9e24231-c8f1-43a2-bc65-596779fe18d1


### 💫 기타사항
