### PR TITLE
[BE] trust proxy 설정 (원본 ip 반환하여 throttler 문제 해결)

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -23,7 +23,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
 		SentimentModule,
 		ThrottlerModule.forRoot([
 			{
-				ttl: 10000, // 10초에
+				ttl: 5000, // 5초에
 				limit: 5, // 5번까지 요청 가능
 			},
 		]),

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -2,10 +2,12 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-	const app = await NestFactory.create(AppModule);
+	const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
+	app.set('trust proxy', 1);
 	app.use(cookieParser());
 
 	// cors 허용


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

nginx 리버스 프록시로 동작하는 배포 상태라 request ip가 모두 web컨테이너 내부ip로 찍힘

throttler가 ip기반으로 정상 동작하기 위해, X-Forwarded-For에 있는 최종 ip를 전달해줘야 함

'trust proxy'를 1로 설정해 이를 해결

### 🫨 고민한 부분

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항

#### 학습 메모

1. [throttler와 reverse proxy](https://trend21c.tistory.com/2295)
2. [NestJS에서 app.set() 적용법](https://github.com/nestjs/nest/issues/2293#issuecomment-500020645)
3. [NestJS Rate Limit 공식문서](https://docs.nestjs.com/security/rate-limiting)
