### PR TITLE
[FE] 이미지 슬라이더 에러 해결

### DIFF
--- a/packages/client/src/features/postModal/ui/ImageSlider.tsx
+++ b/packages/client/src/features/postModal/ui/ImageSlider.tsx
@@ -11,18 +11,14 @@ interface PropsType {
 export default function ImageSlider({ imageUrls }: PropsType) {
 	const [imageIndex, setImageIndex] = useState(0);
 
-	const handlePrev = (e: React.MouseEvent) => {
-		e.preventDefault();
-
+	const handlePrev = () => {
 		setImageIndex((index) => {
 			if (index === 0) return imageUrls.length - 1;
 			return index - 1;
 		});
 	};
 
-	const handleNext = (e: React.MouseEvent) => {
-		e.preventDefault();
-
+	const handleNext = () => {
 		setImageIndex((index) => {
 			if (index === imageUrls.length - 1) return 0;
 			return index + 1;
@@ -51,10 +47,10 @@ export default function ImageSlider({ imageUrls }: PropsType) {
 
 			{imageUrls.length > 1 && (
 				<>
-					<Button onClick={handlePrev} style={{ left: 0 }}>
+					<Button onClick={handlePrev} style={{ left: 0 }} type="button">
 						<ArrowBigLeft />
 					</Button>
-					<Button onClick={handleNext} style={{ right: 0 }}>
+					<Button onClick={handleNext} style={{ right: 0 }} type="button">
 						<ArrowBigRight />
 					</Button>
 					<Pagination>

--- a/packages/client/src/features/postModal/ui/ImageSlider.tsx
+++ b/packages/client/src/features/postModal/ui/ImageSlider.tsx
@@ -11,14 +11,18 @@ interface PropsType {
 export default function ImageSlider({ imageUrls }: PropsType) {
 	const [imageIndex, setImageIndex] = useState(0);
 
-	const handlePrev = () => {
+	const handlePrev = (e: React.MouseEvent) => {
+		e.preventDefault();
+
 		setImageIndex((index) => {
 			if (index === 0) return imageUrls.length - 1;
 			return index - 1;
 		});
 	};
 
-	const handleNext = () => {
+	const handleNext = (e: React.MouseEvent) => {
+		e.preventDefault();
+
 		setImageIndex((index) => {
 			if (index === imageUrls.length - 1) return 0;
 			return index + 1;
@@ -29,7 +33,7 @@ export default function ImageSlider({ imageUrls }: PropsType) {
 		return (
 			<>
 				{imageUrls.map((_, index) => (
-					<Dot onClick={() => setImageIndex(index)}>
+					<Dot key={index} onClick={() => setImageIndex(index)}>
 						{index === imageIndex ? <CircleDot /> : <Circle />}
 					</Dot>
 				))}
@@ -44,6 +48,7 @@ export default function ImageSlider({ imageUrls }: PropsType) {
 					return <Image key={url} src={url} index={imageIndex} />;
 				})}
 			</CurrentImage>
+
 			{imageUrls.length > 1 && (
 				<>
 					<Button onClick={handlePrev} style={{ left: 0 }}>

--- a/packages/client/src/widgets/screen/Screen.tsx
+++ b/packages/client/src/widgets/screen/Screen.tsx
@@ -35,17 +35,17 @@ export default function Screen() {
 	return (
 		<div style={{ height: '100vh', width: '100vw' }}>
 			<Canvas
-				// dpr={dpr}
+				dpr={dpr}
 				camera={camera}
 				onWheel={(e) =>
 					setCameraToCurrentView(cameraToCurrentView + e.deltaY * 휠속도)
 				}
 			>
-				{/* <PerformanceMonitor
+				<PerformanceMonitor
 					onChange={({ factor }) => {
 						setDpr(0.5 + factor / 2);
 					}}
-				/> */}
+				/>
 				<EffectComposer>
 					<Bloom
 						intensity={밝기}

--- a/packages/client/src/widgets/screen/Screen.tsx
+++ b/packages/client/src/widgets/screen/Screen.tsx
@@ -35,17 +35,17 @@ export default function Screen() {
 	return (
 		<div style={{ height: '100vh', width: '100vw' }}>
 			<Canvas
-				dpr={dpr}
+				// dpr={dpr}
 				camera={camera}
 				onWheel={(e) =>
 					setCameraToCurrentView(cameraToCurrentView + e.deltaY * 휠속도)
 				}
 			>
-				<PerformanceMonitor
+				{/* <PerformanceMonitor
 					onChange={({ factor }) => {
 						setDpr(0.5 + factor / 2);
 					}}
-				/>
+				/> */}
 				<EffectComposer>
 					<Bloom
 						intensity={밝기}


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 이미지 슬라이더의 양옆 버튼 클릭시 화면이 새로고침되는 문제 해결

### 🫨 고민한 부분
- 슬라이더의 버튼을 눌렀을 때 화면 새로고침을 어떻게 해결할 지
  - 찾아보니 일반적으로 버튼 클릭 시 폼 제출이 발생하는데, 폼 제출은 페이지를 새로고침한다고 하더라구요
  - 그리고 button의 기본 type 값은 submit이라고 합니다
  - 결과적으로 type 속성을 지정하지 않은 버튼을 form 내부에서 사용하여 페이지가 새로고침되는 것 같네요.
  - 아까 모달창에 form 타입을 준 것 때문에 이렇게 된 것 같습니다
  - 첫 번째 해결방법은 onClick 이벤트 핸들러 내에서 `e.preventDefault()`를 호출하여 버튼 클릭에 대한 기본 동작인 폼 제출을 막는 것입니다
  - 두 번째 해결방법은 간단하게 type="button"을 주는 것입니다
  - 전 두 번째 방법을 사용햇어용

### 🎇 동작 화면
- 에러 해결 전

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/75cf86f9-76d2-46ac-9367-a5ae469fde8e

- 에러 해결 후

https://github.com/boostcampwm2023/web16-B1G1/assets/80266418/c08f37f2-4104-4749-8383-da1d2c6bdb57

### 💫 기타사항
- 뭔가 모달창의 다른 버튼들도 다 다시 테스트해봐야할 것 같네요
- 분명 놓친게 있을듯합니다...


