### PR TITLE
[FE] 전체화면 오류 수정, 감정 분석 에러 처리, 구글 애널리틱스

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -5,10 +5,22 @@
 		<link rel="icon" href="./src/assets/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>별 하나에 글 하나 🌟</title>
+		<script
+			async
+			src="https://www.googletagmanager.com/gtag/js?id=G-NVWSQCSKWF"
+		></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag('js', new Date());
+
+			gtag('config', 'G-NVWSQCSKWF');
+		</script>
 	</head>
 	<body>
 		<div id="root"></div>
-		<div id="modal-root"></div>
 		<script type="module" src="./src/app/App.tsx"></script>
 	</body>
 </html>

--- a/packages/client/src/pages/Home/Home.tsx
+++ b/packages/client/src/pages/Home/Home.tsx
@@ -16,6 +16,7 @@ import { FullScreen, useFullScreenHandle } from 'react-full-screen';
 import UnderBar from 'widgets/underBar/UnderBar';
 import UpperBar from 'widgets/upperBar/UpperBar';
 import CoachMarker from 'features/coachMarker/CoachMarker';
+import styled from '@emotion/styled';
 
 export default function Home() {
 	const [isSwitching, setIsSwitching] = useState<'warp' | 'fade' | 'end'>(
@@ -90,7 +91,7 @@ export default function Home() {
 	return (
 		<FullScreen handle={handleFullScreen}>
 			<Outlet />
-
+			<ModalRoot id="modal-root"></ModalRoot>
 			{status === 'new' && <CoachMarker isFirst={true} />}
 			{isSwitching !== 'end' && (
 				<WarpScreen isSwitching={isSwitching} setIsSwitching={setIsSwitching} />
@@ -104,3 +105,5 @@ export default function Home() {
 		</FullScreen>
 	);
 }
+
+const ModalRoot = styled.div``;

--- a/packages/client/src/shared/lib/constants/error.ts
+++ b/packages/client/src/shared/lib/constants/error.ts
@@ -26,6 +26,7 @@ export const errorMessage: ErrorMessageTypes = {
 		'/auth/signin': '아이디 또는 비밀번호가 일치하지 않습니다.',
 		'/auth/[a-zA-Z]+/signup': '회원가입에 실패했습니다.',
 		'/post': '글 작성에 실패했습니다.',
+		'/sentiment': '감정 분석에 실패했습니다.',
 	},
 
 	patch: {


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 전체화면 오류 수정 
- 감정 분석 에러 처리
- 구글 애널리틱스 스크립트 추가

### 🫨 고민한 부분

모달 포탈의 루트가 FullScreen 컴포넌트의 밖에 있어서 전체화면시 모든 모달이 보이지 않는 버그가 발생했습니다. 어쩔 수 없이 모달 포탈의 루트를 Home 컴포넌트로 이동시켰습니다.

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

<img width="1582" alt="스크린샷 2023-12-12 오전 1 08 23" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/adc2c26f-343b-4045-b8d6-6f3031b4499e">

감정분석 에러 출력

<img width="1280" alt="스크린샷 2023-12-12 오전 1 15 35" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/46828830-bdcc-4469-8568-bee097567f00">

전체화면 모달 출력

### 기타사항
