### PR TITLE
[FE] 별 생성 위치 조정, 별 생성 삭제 애니메이션

### DIFF
--- a/packages/client/src/widgets/starCustomModal/lib/generateStarPosition.ts
+++ b/packages/client/src/widgets/starCustomModal/lib/generateStarPosition.ts
@@ -12,9 +12,12 @@ export const generateStarPosition = async (
 	existingStars: StarData[],
 	size: number,
 ): Promise<StarPosition> => {
-	const x = getRandomFloat(-ARMS_X_DIST * 2, ARMS_X_DIST * 2);
+	const r = getRandomFloat(0, ARMS_X_DIST * 2);
+	const theta = getRandomFloat(0, Math.PI * 2);
+
+	const x = r * Math.cos(theta);
 	const y = getRandomFloat(-GALAXY_THICKNESS, GALAXY_THICKNESS);
-	const z = getRandomFloat(-ARMS_X_DIST * 2, ARMS_X_DIST * 2);
+	const z = r * Math.sin(theta);
 
 	const isOverlap = existingStars.some(({ star }) => {
 		const dist = Math.sqrt(


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- 별의 위치가 사각형 내부에서 생성되던 문제를 해결해 원형으로 생성되도록 했다
- 별 생성 삭제 애니메이션을 만들었다

### 🫨 고민한 부분
useFrame 안에서 setState를 가능한 안하려고 했는데 ref로 참조할수 없는 수치는 이렇다할 방법이 없는것 같더라구요

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

https://github.com/boostcampwm2023/web16-B1G1/assets/78800560/c227103d-f6f6-42c4-8035-3ecf3a930cb9

https://github.com/boostcampwm2023/web16-B1G1/assets/78800560/576c2039-810e-4a26-a7e0-a9044c284ae4

### 💫 기타사항
