### PR TITLE
[BE] 리팩토링, 에러 처리 개선

### DIFF
--- a/packages/server/src/admin/admin.service.ts
+++ b/packages/server/src/admin/admin.service.ts
@@ -12,7 +12,6 @@ import { LogInterceptor } from '../interceptor/log.interceptor';
 import { HttpExceptionFilter } from '../exception-filter/http.exception-filter';
 import * as osUtils from 'os-utils';
 import { exec } from 'child_process';
-import { decryptAes } from '../util/aes.util';
 import { InjectModel } from '@nestjs/mongoose';
 import { Exception } from '../exception-filter/exception.schema';
 import { awsConfig, bucketName } from '../config/aws.config';

--- a/packages/server/src/board/dto/create-board.dto.ts
+++ b/packages/server/src/board/dto/create-board.dto.ts
@@ -4,7 +4,7 @@ import { IsJSON, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 export class CreateBoardDto {
 	@IsNotEmpty({ message: '게시글 제목은 필수 입력입니다.' })
 	@IsString({ message: '게시글 제목은 문자열로 입력해야 합니다.' })
-	@MaxLength(255, { message: '게시글 제목은 255자 이내로 입력해야 합니다.' })
+	@MaxLength(20, { message: '게시글 제목은 20자 이내로 입력해야 합니다.' })
 	@ApiProperty({
 		description: '게시글 제목',
 		example: 'test title',

--- a/packages/server/src/interceptor/transaction.interceptor.ts
+++ b/packages/server/src/interceptor/transaction.interceptor.ts
@@ -2,7 +2,6 @@ import {
 	CallHandler,
 	ExecutionContext,
 	Injectable,
-	InternalServerErrorException,
 	Logger,
 	NestInterceptor,
 } from '@nestjs/common';

--- a/packages/server/src/star/dto/update-star.dto.ts
+++ b/packages/server/src/star/dto/update-star.dto.ts
@@ -1,3 +1,1 @@
-import { PartialType } from '@nestjs/swagger';
-
 export class UpdateStarDto {}


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 별글 생성, 수정 시 제목 20자 제한
- 이미지 업로드 시 파일 확장자 png, jpg, jpeg로 제한, sharp 에러 처리
- 의미없는 Import 제거

### 🫨 고민한 부분

DB 엔티티쪽도 변경해줄 수 있지만 기존 레코드로 인해 DB 에러가 발생할 수 있으므로 엔드포인트 검증만 개선했습니다.

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

### 💫 기타사항
