### PR TITLE
[FE] WarpScreen FadeoutScreen에 onAnimationEnd 추가

### DIFF
--- a/packages/client/src/pages/Home/Home.tsx
+++ b/packages/client/src/pages/Home/Home.tsx
@@ -95,10 +95,9 @@ export default function Home() {
 		<>
 			<Outlet />
 			{status === 'new' && <CoachMarker isFirst={true} />}
-			{isSwitching !== 'end' && (
-				<WarpScreen isSwitching={isSwitching} setIsSwitching={setIsSwitching} />
-			)}
 			{text && <Toast type={type}>{text}</Toast>}
+
+			<WarpScreen isSwitching={isSwitching} setIsSwitching={setIsSwitching} />
 
 			<UpperBar />
 			<UnderBar />

--- a/packages/client/src/widgets/warpScreen/WarpScreen.tsx
+++ b/packages/client/src/widgets/warpScreen/WarpScreen.tsx
@@ -36,7 +36,11 @@ export default function WarpScreen({ isSwitching, setIsSwitching }: PropsType) {
 		zIndex: 999,
 		backgroundColor: theme.colors.background.bdp04,
 	};
-	if (isSwitching === 'fade') return <FadeoutScreen />;
+
+	if (isSwitching === 'end') return null;
+
+	if (isSwitching === 'fade')
+		return <FadeoutScreen onAnimationEnd={() => setIsSwitching('end')} />;
 
 	return (
 		<Canvas camera={camera} style={canvasStyle}>
@@ -50,7 +54,6 @@ export default function WarpScreen({ isSwitching, setIsSwitching }: PropsType) {
 			</EffectComposer>
 
 			<ambientLight intensity={AMBIENT_LIGHT_INTENSITY} />
-
 			<BrightSphere />
 			<SpaceWarp setIsSwitching={setIsSwitching} />
 		</Canvas>

--- a/packages/client/src/widgets/warpScreen/ui/SpaceWarp.tsx
+++ b/packages/client/src/widgets/warpScreen/ui/SpaceWarp.tsx
@@ -13,7 +13,7 @@ import {
 } from '../lib/constants';
 import { WarpStateType } from 'shared/lib';
 
-const geSpaceWarpLinesInfo = () => {
+const getSpaceWarpLinesInfo = () => {
 	const positions = Array.from({ length: SPACE_WARP_LINES_NUM }, () => {
 		const x = getRandomFloat(SPACE_WARP_XZ_MIN, SPACE_WARP_XZ_MAX);
 		const y = getRandomFloat(SPACE_WARP_Y_MIN, SPACE_WARP_Y_MAX);
@@ -38,10 +38,10 @@ interface PropsType {
 }
 
 export default function SpaceWarp({ setIsSwitching }: PropsType) {
-	const [positions, colors] = useMemo(() => geSpaceWarpLinesInfo(), []);
+	const [positions, colors] = useMemo(() => getSpaceWarpLinesInfo(), []);
 
 	useFrame((state, delta) => {
-		if (state.camera.position.y <= 0) {
+		if (state.camera.position.y <= SPACE_WARP_Y_MIN) {
 			state.scene.background = new THREE.Color(0xffffff);
 			setIsSwitching('fade');
 			return;


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항
- FadeoutScreen에 onAnimationEnd를 추가하여, animation이 끝나면 isSwitching이 'end'가 되도록 했습니다.
- isSwitching === 'end'일 경우 WarpScreen에서 null을 리턴하도록 했습니다.
- geSpaceWarpLinesInfo 함수를 geTSpaceWarpLinesInfo로 수정했습니다. 

### 🫨 고민한 부분
- isSwitching이 'end'일 경우를 어디에서 처리할지
  - 개인적으로 컴포넌트 내에서 null을 리턴하는 것이 더 깔끔하다고 생각해서 그렇게 처리했습니다. 

### 📌 중점적으로 볼 부분
- WarpScreen

### 💫 기타사항
