### PR TITLE
[FE] 글 수정 제목 및 본문 제한

### DIFF
--- a/packages/client/src/shared/lib/types/post.ts
+++ b/packages/client/src/shared/lib/types/post.ts
@@ -5,3 +5,5 @@ export interface PostData {
 	images: string[];
 	like_cnt?: number;
 }
+
+export type TextStateTypes = 'DEFAULT' | 'INVALID' | 'OVER';

--- a/packages/client/src/widgets/writingModal/ui/WritingModal.tsx
+++ b/packages/client/src/widgets/writingModal/ui/WritingModal.tsx
@@ -7,8 +7,7 @@ import { usePostStore, useViewStore } from 'shared/store';
 import { Caption } from 'shared/styles';
 import { AlertDialog, Button, Input, Modal, TextArea } from 'shared/ui';
 import Images from './Images';
-
-type TextStateTypes = 'DEFAULT' | 'INVALID' | 'OVER';
+import { TextStateTypes } from 'shared/lib';
 
 export default function WritingModal() {
 	const [titleState, setTitleState] = useState<TextStateTypes>('DEFAULT');


### PR DESCRIPTION
### 📎 이슈번호

### 📃 변경사항

- 글 수정 시 제목과 본문이 비어있어도 걸러지지 않던 부분을 제한해줬습니다.

### 🫨 고민한 부분

- 공백 이슈가 좀 있었네요. 잘 처리되어서 다행입니다 🐧

### 📌 중점적으로 볼 부분

### 🎇 동작 화면

<img width="1582" alt="스크린샷 2023-12-15 오전 1 38 21" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/7c02b4bd-5ed1-4263-ad16-8f590f79432c">

<img width="1582" alt="스크린샷 2023-12-15 오전 1 38 28" src="https://github.com/boostcampwm2023/web16-B1G1/assets/35567292/58915881-9500-40ac-a607-ec97dad60d46">

### 💫 기타사항
